### PR TITLE
updated collectd env file and path

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_configuring-stf-components.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_configuring-stf-components.adoc
@@ -37,7 +37,7 @@
 // The table shows various metadata useful when editing this file.
 After you install the {Project} ({ProjectShort}) server-side components, configure collectd to collect data and store it on the cloud platform side.
 
-. Copy the `/usr/share/openstack-tripleo-heat-templates/metrics/collectd-standalone.yaml` file to your local directory, for example, /home/templates/custom.  Open the file and set additional parameters in the `ExtraConfig` section:
+. Copy the `/usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-standalone.yaml` file to your local directory, for example, /home/templates/custom.  Open the file and set additional parameters in the `ExtraConfig` section:
 +
 ----
 parameter_defaults:

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_configuring-stf-components.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_configuring-stf-components.adoc
@@ -37,7 +37,7 @@
 // The table shows various metadata useful when editing this file.
 After you install the {Project} ({ProjectShort}) server-side components, configure collectd to collect data and store it on the cloud platform side.
 
-. Copy the `/usr/share/openstack-tripleo-heat-templates/environments/collectd-environment.yaml` file to your local directory, for example, /home/templates/custom.  Open the file and set additional parameters in the `ExtraConfig` section:
+. Copy the `/usr/share/openstack-tripleo-heat-templates/metrics/collectd-standalone.yaml` file to your local directory, for example, /home/templates/custom.  Open the file and set additional parameters in the `ExtraConfig` section:
 +
 ----
 parameter_defaults:
@@ -51,14 +51,14 @@ parameter_defaults:
      collectd::plugin::virt::hostname_format: "hostname uuid"
 ----
 +
-By default, collectd includes the disk, interface, load, memory, processes, and tcpconns plug-ins. You can add additional plug-ins using the `CollectdExtraPlugins` parameter. You can also provide additional configuration information for the `CollectdExtraPlugins` using the `ExtraConfig` option as shown. The `CollectdExtraPlugins` example adds the virt plug-in and configures the connection string and the hostname format.
+By default, collectd includes the `disk`, `interface`, `load`, `memory`, `processes`, and `tcpconns` plug-ins. You can add additional plug-ins using the `CollectdExtraPlugins` parameter. You can also provide additional configuration information for the `CollectdExtraPlugins` by using the `ExtraConfig` option, as shown. The `CollectdExtraPlugins` example adds the `virt` plug-in, and configures the connection string and the hostname format.
 
 . Include the modified YAML files in the `openstack overcloud deploy` command:
 +
 ----
 $ openstack overcloud deploy
 --templates /home/templates/environments/collectd.yaml \
--e /home/templates/custom/collectd-environment.yaml
+-e /home/templates/custom/collectd-standalone.yaml
 ----
 +
 To view the collectd plug-ins and configurations, see <<appe-stf-collectd-plugins>>.


### PR DESCRIPTION
Changed the path of collectd environment file to /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-standalone.yaml and changed the overcloud deployment command accordingly to reflect -e collectd-standalone.yaml