### PR TITLE
Don't use starting CSV version

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -244,7 +244,6 @@ spec:
   name: amq7-cert-manager
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: amq7-cert-manager.v1.0.0
 EOF
 ----
 
@@ -282,7 +281,6 @@ spec:
   name: elastic-cloud-eck
   source: operatorhubio-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: elastic-cloud-eck.v1.1.0
 EOF
 ----
 


### PR DESCRIPTION
Using a starting CSV doesn't result in _that_ version of the CSV being installed, but
rather results in the starting version which then automatically upgrades through each
of the Operator versions. The upgrades happen because our default is to allow the operators
to upgrade themselves.
