### PR TITLE
Remove storageResources from example manifest

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -58,7 +58,6 @@ spec:
       storage:
         strategy: persistent
         persistent:
-          storageResources: {}
           storageSelector: {}
           pvcStorageRequest: 20G
   backends:
@@ -69,7 +68,6 @@ spec:
         storage:
           strategy: persistent
           persistent:
-            storageResources: {}
             storageSelector: {}
             pvcStorageRequest: 20G
     events:


### PR DESCRIPTION
* It's no longer part of the CRD
* See
https://github.com/infrawatch/service-telemetry-operator/pull/150/files#diff-d899cda001ed71af821c82d1916b247a4e9ce1d1be83a46b85b19d8cc67c4765L58