### PR TITLE
Update documentation for metrics data retention

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_overview-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_overview-of-the-servicetelemetry-object.adoc
@@ -120,4 +120,4 @@ Use The `highAvailability` parameter to control the instantiation of multiple co
 
 === transports
 
-Use the `transports` parameter to control the enablement of the message bus for a {ProjectShort} deployment. The only transport currently supported is {MessageBus}. Ensure that it is enabled for proper operation of {ProjectShort}. By default, the qdr transport is enabled.
+Use the `transports` parameter to control the enablement of the message bus for a {ProjectShort} deployment. The only transport currently supported is {MessageBus}. Ensure that it is enabled for proper operation of {ProjectShort}. By default, the `qdr` transport is enabled.

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -67,6 +67,7 @@ spec:
         scrapeInterval: 10s
         storage:
           strategy: persistent
+          retention: 24h
           persistent:
             storageSelector: {}
             pvcStorageRequest: 20G
@@ -87,6 +88,8 @@ spec:
   transports:
     qdr:
       enabled: true
+      web:
+        enabled: false
   highAvailability:
     enabled: false
   clouds:

--- a/doc-Service-Telemetry-Framework/modules/proc_preparing-your-openshift-environment-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_preparing-your-openshift-environment-for-stf.adoc
@@ -39,19 +39,15 @@ As you prepare your {OpenShiftShort} environment for {ProjectShort}, you must pl
 .Additional resources
 For more information about configuring persistent storage for {OpenShiftShort}, see https://docs.openshift.com/container-platform/{SupportedOpenShiftVersion}/storage/understanding-persistent-storage.html[Understanding persistent storage.]
 
-
 [id="ephemeral-storage"]
 === Using ephemeral storage
 
 [WARNING]
 You can use ephemeral storage with {ProjectShort}. However, if you use ephemeral storage, you might experience data loss if a pod is restarted, updated, or rescheduled onto another node. Use ephemeral storage only for development or testing, and not production environments.
 
-
-
 .Additional resources
 
 For more information about enabling ephemeral storage for {ProjectShort}, see xref:configuring-ephemeral-storage_advanced-features[].
-
 
 [id="resource-allocation"]
 == Resource allocation
@@ -65,6 +61,17 @@ The amount of resources that you require to run {ProjectShort} depends on your e
 * For recommendations about sizing for metrics collection, see https://access.redhat.com/articles/4907241.
 
 * For information about sizing requirements for ElasticSearch, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html.
+
+[id="metrics-retention-time-period"]
+== Metrics retention time period
+
+Metrics are stored in Prometheus for a time period of 24 hours by default, providing an overview of the cloud systems and enough data to allow for trends to develop for alerting. To adjust STF for additional metrics retention time set a new value in `backends.metrics.prometheus.storage.retention` such as `7d` for seven days. Long retention periods are not recommended as returning data from heavily populated Prometheus systems could result in queries returning slowly.
+
+For long term storage, use of systems designed for long term data retention such as https://thanos.io/[Thanos], should be used.
+
+.Additional resources
+
+* For recommendations about Prometheus data storage and estimating storage space, see https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects
 
 [id="node-tuning-operator"]
 == Node tuning operator

--- a/doc-Service-Telemetry-Framework/modules/proc_preparing-your-openshift-environment-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_preparing-your-openshift-environment-for-stf.adoc
@@ -65,7 +65,7 @@ The amount of resources that you require to run {ProjectShort} depends on your e
 [id="metrics-retention-time-period"]
 == Metrics retention time period
 
-By default, metrics are stored in Prometheus for a time period of 24 hours, providing an overview of the cloud systems and enough data to allow for trends to develop for alerting. To adjust {ProjectShort} for additional metrics retention time, set a new value in `backends.metrics.prometheus.storage.retention`, for example, `7d` for seven days. If you use long retention periods, returning data from heavily populated Prometheus systems can result in queries returning slowly.
+The default retention time for metrics stored in {ProjectShort} is 24 hours, which provides enough data to allow for trends to develop for the purposes of alerting. To adjust {ProjectShort} for additional metrics retention time, set a new value in `backends.metrics.prometheus.storage.retention`, for example, `7d` for seven days. If you use long retention periods, returning data from heavily populated Prometheus systems can result in queries returning slowly.
 
 For long-term storage, use systems designed for long-term data retention, for example, https://thanos.io/[Thanos].
 

--- a/doc-Service-Telemetry-Framework/modules/proc_preparing-your-openshift-environment-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_preparing-your-openshift-environment-for-stf.adoc
@@ -65,7 +65,7 @@ The amount of resources that you require to run {ProjectShort} depends on your e
 [id="metrics-retention-time-period"]
 == Metrics retention time period
 
-Metrics are stored in Prometheus for a time period of 24 hours by default, providing an overview of the cloud systems and enough data to allow for trends to develop for alerting. To adjust STF for additional metrics retention time set a new value in `backends.metrics.prometheus.storage.retention` such as `7d` for seven days. Long retention periods are not recommended as returning data from heavily populated Prometheus systems could result in queries returning slowly.
+By default, metrics are stored in Prometheus for a time period of 24 hours, providing an overview of the cloud systems and enough data to allow for trends to develop for alerting. To adjust {ProjectShort} for additional metrics retention time, set a new value in `backends.metrics.prometheus.storage.retention`, for example, `7d` for seven days. If you use long retention periods, returning data from heavily populated Prometheus systems can result in queries returning slowly.
 
 For long-term storage, use systems designed for long-term data retention, for example, https://thanos.io/[Thanos].
 

--- a/doc-Service-Telemetry-Framework/modules/proc_preparing-your-openshift-environment-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_preparing-your-openshift-environment-for-stf.adoc
@@ -67,7 +67,7 @@ The amount of resources that you require to run {ProjectShort} depends on your e
 
 Metrics are stored in Prometheus for a time period of 24 hours by default, providing an overview of the cloud systems and enough data to allow for trends to develop for alerting. To adjust STF for additional metrics retention time set a new value in `backends.metrics.prometheus.storage.retention` such as `7d` for seven days. Long retention periods are not recommended as returning data from heavily populated Prometheus systems could result in queries returning slowly.
 
-For long term storage, use of systems designed for long term data retention such as https://thanos.io/[Thanos], should be used.
+For long-term storage, use systems designed for long-term data retention, for example, https://thanos.io/[Thanos].
 
 .Additional resources
 


### PR DESCRIPTION
Update the documentation for the new Prometheus retention time period configuration option in the
ServiceTelemetry object. Makes note that Prometheus should not be used for long term data retention
and instead should make use of systems such as Thanos.

Updates the default configuration sample to address a recently merged patch that allows configuring
whether the QDR web interface is exposed by default (default is now off).

Related: https://github.com/infrawatch/service-telemetry-operator/pull/163
Related: https://github.com/infrawatch/service-telemetry-operator/pull/162
