### PR TITLE
Use the proper stable-1.2 channel

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -326,7 +326,7 @@ metadata:
   name: service-telemetry-operator
   namespace: service-telemetry
 spec:
-  channel: stable
+  channel: stable-1.2
   installPlanApproval: Automatic
   name: service-telemetry-operator
   source: infrawatch-operators
@@ -344,7 +344,7 @@ metadata:
   name: service-telemetry-operator
   namespace: service-telemetry
 spec:
-  channel: stable
+  channel: stable-1.2
   installPlanApproval: Automatic
   name: service-telemetry-operator
   source: redhat-operators-stf


### PR DESCRIPTION
Use the proper stable-1.2 channel for the Operator subscription for Service
Telemetry Operator.
