### PR TITLE
Jof ocp4.6 changes

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
@@ -25,13 +25,13 @@ You can use Operators to load the various application components and objects. Ea
 
 .Prerequisites
 
-* {OpenShift} ({OpenShiftShort}) version 4.5 is running.
+* {OpenShift} ({OpenShiftShort}) version 4.5 or 4.6 is running.
 * You have prepared your {OpenShift} ({OpenShiftShort}) environment and ensured that there is persistent storage and enough resources to run the {ProjectShort} components on top of the {OpenShiftShort} environment.
 
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{OpenShift} version 4.5 is currently required for a successful installation of {ProjectShort}.
+{Project} ({ProjectShort}) is compatible with {OpenShift} versions 4.5 and 4.6.
 
 //For more information about migrating, see https://access.redhat.com/articles/5477371[Migrating Service Telemetry Framework v1.0 from OperatorSource to CatalogSource].
 endif::[]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -23,7 +23,7 @@ ifdef::context[:parent-context: {context}]
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{OpenShift} version 4.5 is currently required for a successful installation of {ProjectShort}. 
+{Project} ({ProjectShort}) is compatible with {OpenShift} versions 4.5 and 4.6.
 
 //For more information about migrating, see https://access.redhat.com/articles/5477371[Migrating Service Telemetry Framework v1.0 from OperatorSource to CatalogSource].
 endif::[]

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -204,7 +204,7 @@ spec:
 EOF
 ----
 
-. If you are using {OpenShiftShort} 4.6, install the Red Hat CatalogSource:
+. If you are using {OpenShiftShort} 4.6, Subscribe to the AMQ Certificate Manager Operator via the `redhat-operators-stf` CatalogSource:
 
 +
 [source,bash]

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -224,7 +224,7 @@ spec:
 EOF
 ----
 
-. If you are using {OpenShiftShort} 4.5, subscribe to the AMQ Certificate Manager Operator, create the subscription, and validate the AMQ7 Certificate Manager:
+. If you are using {OpenShiftShort} 4.5, subscribe to the AMQ Certificate Manager Operator, create the subscription, and validate the AMQ Certificate Manager:
 +
 [NOTE]
 The AMQ Certificate Manager is installed globally for all namespaces, so the `namespace` value provided is `openshift-operators`. You might not see your `amq7-cert-manager.v1.0.0` ClusterServiceVersion in the `service-telemetry` namespace for a few minutes until the processing executes against the namespace.

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -179,11 +179,11 @@ endif::[]
 You must subscribe to the AMQ Certificate Manager Operator before you deploy the other {ProjectShort} components because the AMQ Certificate Manager Operator runs globally-scoped. The AMQ Certificate Manager Operator is not compatible with the dependency management of Operator Lifecycle Manager when you use it with other namespace-scoped operators.
 
 [NOTE]
-If you are using OpenShift Container Platform 4.5, go directly to step 3.
+If you are using {OpenShift} ({OpenShiftShort}) 4.5, go directly to step 3.
 
 .Procedure
 
-. If you are using OCP 4.6, enable the Red Hat CatalogSource:
+. If you are using {OpenShiftShort} 4.6, enable the Red Hat CatalogSource:
 +
 [source,bash]
 ----
@@ -204,7 +204,7 @@ spec:
 EOF
 ----
 
-. If you are using OCP 4.6, run the Red Hat CatalogSource:
+. If you are using {OpenShiftShort} 4.6, install the Red Hat CatalogSource:
 
 +
 [source,bash]
@@ -224,7 +224,7 @@ spec:
 EOF
 ----
 
-. If you are using OCP 4.5, subscribe to the AMQ Certificate Manager Operator, create the subscription, and validate the AMQ7 Certificate Manager:
+. If you are using {OpenShiftShort} 4.5, subscribe to the AMQ Certificate Manager Operator, create the subscription, and validate the AMQ7 Certificate Manager:
 +
 [NOTE]
 The AMQ Certificate Manager is installed globally for all namespaces, so the `namespace` value provided is `openshift-operators`. You might not see your `amq7-cert-manager.v1.0.0` ClusterServiceVersion in the `service-telemetry` namespace for a few minutes until the processing executes against the namespace.
@@ -247,7 +247,7 @@ spec:
 EOF
 ----
 
-. For OCP 4.5 and OCP 4.6, to validate your `ClusterServiceVersion`, use the `oc get csv` command:
+. For {OpenShiftShort} versions 4.5 and OCP 4.6, to validate your `ClusterServiceVersion`, use the `oc get csv` command:
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -172,14 +172,59 @@ smart-gateway-operator                        InfraWatch Operators       7m20s
 ----
 endif::[]
 
+
 [id="subscribing-to-the-amq-certificate-manager-operator"]
 == Subscribing to the AMQ Certificate Manager Operator
 
 You must subscribe to the AMQ Certificate Manager Operator before you deploy the other {ProjectShort} components because the AMQ Certificate Manager Operator runs globally-scoped. The AMQ Certificate Manager Operator is not compatible with the dependency management of Operator Lifecycle Manager when you use it with other namespace-scoped operators.
 
+[NOTE]
+If you are using OpenShift Container Platform 4.5, go directly to step 3.
+
 .Procedure
 
-. Subscribe to the AMQ Certificate Manager Operator, create the subscription, and validate the AMQ7 Certificate Manager:
+. If you are using OCP 4.6, enable the Red Hat CatalogSource:
++
+[source,bash]
+----
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: redhat-operators-stf
+  namespace: openshift-marketplace
+spec:
+  displayName: Red Hat STF Operators
+  image: quay.io/redhat-operators-stf/stf-catalog:v4.6
+  publisher: Red Hat
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+EOF
+----
+
+. If you are using OCP 4.6, run the Red Hat CatalogSource:
+
++
+[source,bash]
+----
+$ oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: amq7-cert-manager
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: amq7-cert-manager
+  source: redhat-operators-stf
+  sourceNamespace: openshift-marketplace
+EOF
+----
+
+. If you are using OCP 4.5, subscribe to the AMQ Certificate Manager Operator, create the subscription, and validate the AMQ7 Certificate Manager:
 +
 [NOTE]
 The AMQ Certificate Manager is installed globally for all namespaces, so the `namespace` value provided is `openshift-operators`. You might not see your `amq7-cert-manager.v1.0.0` ClusterServiceVersion in the `service-telemetry` namespace for a few minutes until the processing executes against the namespace.
@@ -202,7 +247,7 @@ spec:
 EOF
 ----
 
-. To validate your `ClusterServiceVersion`, use the `oc get csv` command:
+. For OCP 4.5 and OCP 4.6, to validate your `ClusterServiceVersion`, use the `oc get csv` command:
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----


### PR DESCRIPTION
Updated note in Intro module and Installing the core components of Service Telemetry Framework assembly.
Inserted two steps into "Subscribing to the AMQ Certificate Manager Operator" for OCP 4.6.

