### PR TITLE
Add missing parameter when monitoring OSP services (#179)

### DIFF
--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -1,4 +1,4 @@
-= Service Telemetry Framework 1.3
+= Service Telemetry Framework 1.2
 OpenStack Documentation Team <rhos-docs@redhat.com>
 :imagesdir: images
 :vernum: 16.1

--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -1,4 +1,4 @@
-= Service Telemetry Framework 1.2
+= Service Telemetry Framework 1.3
 OpenStack Documentation Team <rhos-docs@redhat.com>
 :imagesdir: images
 :vernum: 16.1

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
@@ -165,6 +165,7 @@ parameter_defaults:
         cloud1-telemetry:     # <4>
             format: JSON
             presettle: true
+    CollectdEnableSensubility: true # <7>
     CollectdSensubilityTransport: amqp1
     CollectdSensubilityResultsChannel: collectd/cloud1-notify # <5>
 
@@ -183,6 +184,7 @@ parameter_defaults:
           role: edge
           verifyHostname: false
           sslProfile: sslProfile
+
 ----
 endif::include_when_16[]
 <1> Define the topic for Ceilometer events. This value is the address format of `anycast/ceilometer/cloud1-event.sample`.
@@ -191,6 +193,7 @@ endif::include_when_16[]
 <4> Define the topic for collectd metrics. This value is the format of `collectd/cloud1-telemetry`.
 <5> Define the topic for collectd-sensubility events. This should be the exact string format of `collectd/cloud1-notify`
 <6> Adjust the `MetricsQdrConnectors` host to the address of the {ProjectShort} route.
+<7> Enable monitoring of health and API status.
 +
 . Ensure that the naming convention in the `stf-connectors.yaml` file aligns with the `spec.amqpUrl` field in the Smart Gateway configuration. For example, configure the `CeilometerQdrEventsConfig.topic` field to a value of `cloud1-event`.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_monitoring-resource-usage-of-openstack-services.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_monitoring-resource-usage-of-openstack-services.adoc
@@ -42,6 +42,7 @@ Monitor the resource usage of the {OpenStack} services, such as the APIs and oth
 +
 ----
   CollectdEnableLibpodstats: true
+  CollectdEnableSensubility: true
 ----
 
 . Continue with the overcloud deployment procedure.


### PR DESCRIPTION
* Add missing parameter when monitoring OSP services

Add CollectdEnableSensubility: true to the stf-connectors.yaml when
enabling resource usage monitoring of OpenStack services.

Resolves: rhbz#1954155

* Inserted "CollectdEnableSensubility: true" into section 5.6.4. Creating the OpenStack environment file

* Add configuration to OpenStack environment file as well

* Update doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc

Two instances of the same parameter.

* Update doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc

Co-authored-by: Joanne O'Flynn <joflynn@redhat.com>
Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>