### PR TITLE
Fix missing colon in ifdef for 17.0

### DIFF
--- a/common/stf-attributes.adoc
+++ b/common/stf-attributes.adoc
@@ -17,7 +17,7 @@ ifeval::[{vernum} < 16.0]
 endif::[]
 
 ifeval::[{vernum} >= 17.0]
-:include_when_17
+:include_when_17:
 endif::[]
 
 ifeval::["{build}" == "upstream"]


### PR DESCRIPTION
Caused ugliness, then didn't