### PR TITLE
Document retrieving and usage of QDR CA cert (#187)

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
@@ -26,6 +26,11 @@ To deploy data collection and transport to {ProjectShort} on {OpenStack} cloud n
 
 
 include::../modules/proc_deploying-to-non-standard-network-topologies.adoc[leveloffset=+1]
+
+ifdef::include_when_13[]
+include::../modules/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc[leveloffset=+1]
+endif::include_when_13[]
+
 include::../modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc[leveloffset=+1]
 include::../modules/proc_validating-clientside-installation.adoc[leveloffset=+2]
 

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -136,7 +136,13 @@ parameter_defaults:
         sslProfile: sslProfile
         verifyHostname: false
     MetricsQdrSSLProfiles:
+ifdef::include_when_13[]
     -   name: sslProfile
+        caCertFileContent: |
+          ----BEGIN CERTIFICATE----
+          <snip>
+          ----END CERTIFICATE----
+endif::include_when_13[]
     ExtraConfig:
         collectd::plugin::cpu::reportbycpu: true
         collectd::plugin::cpu::reportbystate: true

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
@@ -103,7 +103,10 @@ parameter_defaults:
 
     MetricsQdrSSLProfiles:
         - name: sslProfile
-
+          caCertFileContent: |
+            ----BEGIN CERTIFICATE----
+            <snip>
+            ----END CERTIFICATE----
     MetricsQdrConnectors:
         - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch   # <5>
           port: 443
@@ -177,7 +180,12 @@ parameter_defaults:
 
     MetricsQdrSSLProfiles:
         - name: sslProfile
-
+ifdef::include_when_13[]
+          caCertFileContent: |
+            ----BEGIN CERTIFICATE----
+            <snip>
+            ----END CERTIFICATE----
+endif::include_when_13[]
     MetricsQdrConnectors:
         - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch   # <6>
           port: 443
@@ -201,7 +209,6 @@ endif::include_when_16[]
 
 . Source the authentication file:
 +
-[source,bash]
 ----
 [stack@undercloud-0 ~]$ source stackrc
 

--- a/doc-Service-Telemetry-Framework/modules/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+// This module can be included from assemblies using the following include statement:
+// include::<path>/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc[leveloffset=+1]
+
+// The file name and the ID are based on the module title. For example:
+// * file name: proc_doing-procedure-a.adoc
+// * ID: [id='proc_doing-procedure-a_{context}']
+// * Title: = Doing procedure A
+//
+// The ID is used as an anchor for linking to the module. Avoid changing
+// it after the module has been published to ensure existing links are not
+// broken.
+//
+// The `context` attribute enables module reuse. Every module's ID includes
+// {context}, which ensures that the module has a unique ID even if it is
+// reused multiple times in a guide.
+//
+// Start the title with a verb, such as Creating or Create. See also
+// _Wording of headings_ in _The IBM Style Guide_.
+[id="getting-ca-certificate-from-stf-for-overcloud-configuration_{context}"]
+= Getting CA certificate from {Project} for overcloud configuration
+
+[role="_abstract"]
+To connect your {OpenStack} overcloud to {Project} ({ProjectShort}), retrieve the CA certificate of {MessageBus} that runs within {Project} and use the certificate in the {OpenStack} configuration.
+
+.Procedure
+
+. View a list of available certificates in {Project}:
++
+[source,bash,options="nowrap",subs="verbatim"]
+----
+$ oc get secrets
+----
+
+. Retrieve and note the content of the `default-interconnect-selfsigned` Secret:
++
+[source,bash,options="nowrap",subs="verbatim"]
+----
+$ oc get secret/default-interconnect-selfsigned -o jsonpath='{.data.ca\.crt}' | base64 -d
+----
+
+. Add the content from the `default-interconnect-selfsigned` Secret to the {OpenStack} configuration in the `stf-connectors.yaml` file. Insert the content to the `caCertFileContent` parameter within `MetricsQdrSSLProfiles`:
++
+[source,yaml]
+----
+  MetricsQdrConnectors:
+  - host: default-interconnect-5671-service-telemetry.apps.infra.watch
+    port: 443
+    role: edge
+    sslProfile: sslProfile
+    verifyHostname: false
+
+  MetricsQdrSSLProfiles:
+    name: sslProfile
+    caCertFileContent: |
+      ----BEGIN CERTIFICATE----
+      <snip>
+      ----END CERTIFICATE----
+----


### PR DESCRIPTION
Cherry-pick from master to stable-1.2

* Document retrieving and usage of QDR CA cert

Adds documentation of retrieval peocess of CA certificate for QDR on server side\
and it's usage on client side.

* Update doc-Service-Telemetry-Framework/modules/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc

Co-authored-by: Leif Madsen <lmadsen@redhat.com>

* Update doc-Service-Telemetry-Framework/modules/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc

Co-authored-by: Leif Madsen <lmadsen@redhat.com>

* Update doc-Service-Telemetry-Framework/modules/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc

Co-authored-by: Leif Madsen <lmadsen@redhat.com>

* Update doc-Service-Telemetry-Framework/modules/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc

Co-authored-by: Leif Madsen <lmadsen@redhat.com>

* Update doc-Service-Telemetry-Framework/modules/proc_getting-ca-certificate-from-stf-for-overcloud-configuration.adoc

* wrapper for v13 (#193)

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>
Co-authored-by: Leif Madsen <lmadsen@redhat.com>