### PR TITLE
Section on sending metrics to STF and Gnocchi

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
@@ -32,6 +32,7 @@ include::../modules/proc_getting-ca-certificate-from-stf-for-overcloud-configura
 endif::include_when_13[]
 
 include::../modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc[leveloffset=+1]
+include::../modules/proc_configuring-gnocchi-metrics.adoc[leveloffset=+1]
 include::../modules/proc_validating-clientside-installation.adoc[leveloffset=+2]
 
 //reset the context

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -36,7 +36,7 @@ parameter_defaults:
     PipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
 ----
 
-. Add the environment file `publish-to-gnocchi.yaml` to the deployment command. Replace <other-argruments> with files that are applicable to your environment:
+. Add the environment file `gnocchi-connectors.yaml` to the deployment command. Replace <other-argruments> with files that are applicable to your environment:
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -37,7 +37,7 @@ parameter_defaults:
     PipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
 ----
 
-. Add the environment file `publish-to-gnocchi.yaml` to the deployment command:
+. Add the environment file `publish-to-gnocchi.yaml` to the deployment command. Replace <other-argruments> with files that are applicable to your environment:
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -68,4 +68,5 @@ sinks:
           - gnocchi://?filter_project=service&archive_policy=high
           - notifier://172.17.1.35:5666/?driver=amqp&topic=metering
 ----
-Important here is that publishers contain both notifier and gnocchi
++
+Ensure that the `publishers` section of the file contains information for both notifier and gnocchi.

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -3,7 +3,6 @@
 [role="_abstract"]
 
 To send metrics to {Project} ({ProjectShort}} and gnocchi simultaneously, you must include another configuration file to your deployment. 
-following templates have to be added in addition to the templates
 mentioned above.
 
 .Prerequisites

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -10,7 +10,7 @@ To send metrics to {Project} ({ProjectShort}} and gnocchi simultaneously, you mu
 
 .Procedure
 
-. Create a configuration file named `publish-to-gnocchi.yaml` in the
+. Create an environment file named `gnocchi-connectors.yaml` in the
 `/home/stack` directory.
 +
 [source,yaml]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -46,7 +46,7 @@ $ openstack overcloud deploy <other-arguments>
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/enable-stf.yaml \
   --environment-file /home/stack/stf-connectors.yaml \
-  --environment-file /home/stack/publish-to-gnocchi.yaml
+  --environment-file /home/stack/gnocchi-connectors.yaml
 ----
 
 . Verification: To verify that the configuration was successful, verify the content

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -8,7 +8,7 @@ mentioned above.
 
 .Prerequisites
 
-An OpenStack environment file was created, see xref:configuring-the-stf-connection-for-the-overcloud[].
+* You have created a file that contains the connection configuration of the AMQ Interconnect for the overcloud to the {ProjectShort} deployment. For more information, see xref:configuring-the-stf-connection-for-the-overcloud[].
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -38,7 +38,7 @@ parameter_defaults:
     PipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
 ----
 
-The template should be added to the overcloud deploy command.
+. Add the environment file `publish-to-gnocchi.yaml` to the deployment command:
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -6,7 +6,7 @@ To send metrics to {Project} ({ProjectShort}} and gnocchi simultaneously, you mu
 
 .Prerequisites
 
-* You have created a file that contains the connection configuration of the AMQ Interconnect for the overcloud to the {ProjectShort} deployment. For more information, see xref:configuring-the-stf-connection-for-the-overcloud[].
+* You have created a file that contains the connection configuration of the {MessageBus} for the overcloud to {ProjectShort}. For more information, see xref:configuring-the-stf-connection-for-the-overcloud[].
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -39,7 +39,7 @@ parameter_defaults:
 ----
 
 The template should be added to the overcloud deploy command.
-
++
 [source,bash,options="nowrap",subs="+quotes"]
 ----
 openstack overcloud deploy <other arguments>

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -42,7 +42,7 @@ The template should be added to the overcloud deploy command.
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----
-openstack overcloud deploy <other arguments>
+$ openstack overcloud deploy <other arguments>
   --templates /usr/share/openstack-tripleo-heat-templates \
   --environment-file <...other-environment-files...> \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -2,7 +2,7 @@
 
 [role="_abstract"]
 
-In order to send metrics to STF and at the same time to gnocchi, the
+To send metrics to {Project} ({ProjectShort}} and gnocchi simultaneously, you must include another configuration file to your deployment. 
 following templates have to be added in addition to the templates
 mentioned above.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -1,0 +1,73 @@
+= Sending metrics to Gnocchi and to {ProjectShort}
+
+[role="_abstract"]
+
+In order to send metrics to STF and at the same time to gnocchi, the
+following templates have to be added in addition to the templates
+mentioned above.
+
+.Prerequisites
+
+An OpenStack environment file was created, see xref:configuring-the-stf-connection-for-the-overcloud[].
+
+.Procedure
+
+. Create a configuration file named `publish-to-gnocchi.yaml` in the
+`/home/stack` directory.
+
+[source,yaml]
+----
+resource_registry:
+    OS::TripleO::Services::GnocchiApi: /usr/share/openstack-tripleo-heat-templates/deployment/gnocchi/gnocchi-api-container-puppet.yaml
+    OS::TripleO::Services::GnocchiMetricd: /usr/share/openstack-tripleo-heat-templates/deployment/gnocchi/gnocchi-metricd-container-puppet.yaml
+    OS::TripleO::Services::GnocchiStatsd: /usr/share/openstack-tripleo-heat-templates/deployment/gnocchi/gnocchi-statsd-container-puppet.yaml
+    OS::TripleO::Services::AodhApi: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-api-container-puppet.yaml
+    OS::TripleO::Services::AodhEvaluator: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-evaluator-container-puppet.yaml
+    OS::TripleO::Services::AodhNotifier: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-notifier-container-puppet.yaml
+    OS::TripleO::Services::AodhListener: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-listener-container-puppet.yaml
+    OS::TripleO::Services::PankoApi: /usr/share/openstack-tripleo-heat-templates/deployment/deprecated/panko/panko-api-container-puppet.yaml
+
+parameter_defaults:
+    CeilometerEnableGnocchi: true
+    CeilometerEnablePanko: false
+    GnocchiArchivePolicy: 'high'
+    GnocchiBackend: 'rbd'
+    GnocchiRbdPoolName: 'metrics'
+
+    EventPipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
+    PipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
+----
+
+The template should be added to the overcloud deploy command.
+
+[source,bash,options="nowrap",subs="+quotes"]
+----
+openstack overcloud deploy <other arguments>
+  --templates /usr/share/openstack-tripleo-heat-templates \
+  --environment-file <...other-environment-files...> \
+  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
+  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/enable-stf.yaml \
+  --environment-file /home/stack/stf-connectors.yaml \
+  --environment-file /home/stack/publish-to-gnocchi.yaml
+----
+
+After the deployment successfully finished, to verify the configuration was successful, verify the content
+of the file `/var/lib/config-data/puppet-generated/ceilometer/etc/ceilometer/pipeline.yaml` on a controller
+node:
+
+[source,yaml]
+----
+sources:
+    - name: meter_source
+      meters:
+          - "*"
+      sinks:
+          - meter_sink
+sinks:
+    - name: meter_sink
+      publishers:
+          - gnocchi://?filter_project=service&archive_policy=high
+          - notifier://172.17.1.35:5666/?driver=amqp&topic=metering
+----
+Important here is that publishers contain both notifier and gnocchi
+sections.

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -2,8 +2,7 @@
 
 [role="_abstract"]
 
-To send metrics to {Project} ({ProjectShort}} and gnocchi simultaneously, you must include another configuration file to your deployment. 
-mentioned above.
+To send metrics to {Project} ({ProjectShort}} and gnocchi simultaneously, you must include an environment file to your deployment to enable an additional publisher.
 
 .Prerequisites
 

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -69,4 +69,3 @@ sinks:
           - notifier://172.17.1.35:5666/?driver=amqp&topic=metering
 ----
 Important here is that publishers contain both notifier and gnocchi
-sections.

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -52,7 +52,7 @@ openstack overcloud deploy <other arguments>
 ----
 
 After the deployment successfully finished, to verify the configuration was successful, verify the content
-of the file `/var/lib/config-data/puppet-generated/ceilometer/etc/ceilometer/pipeline.yaml` on a controller
+of the file `/var/lib/config-data/puppet-generated/ceilometer/etc/ceilometer/pipeline.yaml` on a Controller
 node:
 
 [source,yaml]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -14,7 +14,7 @@ mentioned above.
 
 . Create a configuration file named `publish-to-gnocchi.yaml` in the
 `/home/stack` directory.
-
++
 [source,yaml]
 ----
 resource_registry:

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -51,7 +51,7 @@ openstack overcloud deploy <other arguments>
   --environment-file /home/stack/publish-to-gnocchi.yaml
 ----
 
-After the deployment successfully finished, to verify the configuration was successful, verify the content
+. Verification: To verify that the configuration was successful, verify the content
 of the file `/var/lib/config-data/puppet-generated/ceilometer/etc/ceilometer/pipeline.yaml` on a Controller
 node:
 

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -41,7 +41,7 @@ parameter_defaults:
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----
-$ openstack overcloud deploy <other arguments>
+$ openstack overcloud deploy <other-arguments>
   --templates /usr/share/openstack-tripleo-heat-templates \
   --environment-file <...other-environment-files...> \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \


### PR DESCRIPTION
This section describes how to send metrics to both, STF and traditional telemetry.