### PR TITLE
Mention cloud dashboard and enhanced deployment instructions

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -155,7 +155,7 @@ $ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/dep
 grafanadashboard.integreatly.org/rhos-cloud-dashboard created
 ----
 [WARNING]
-Some panels in the cloud dashboard require specific values be configured for the collectd virt plugin hostname_format parameter in the stf-connectors.yaml. If not configured some panels in the dashboard will be affected.
+Some panels in the cloud dashboard require the collect virt plugin hostname_format to be set to `name uuid hostname` in the stf-connectors.yaml. If not configured, affected dashboards will remain empty.
 [source,yaml]
 ---
 parameter_defaults:

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -123,8 +123,8 @@ $ oc get route grafana-route
 ----
 +
 ----
-NAME            HOST/PORT                                                                   PATH   SERVICES          PORT   TERMINATION   WILDCARD
-grafana-route   grafana-route-service-telemetry.apps.ocp46stf.lab.upshift.rdu2.redhat.com          grafana-service   3000   edge          None
+NAME            HOST/PORT                                          PATH   SERVICES          PORT   TERMINATION   WILDCARD
+grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None
 ----
 
 [id="importing-dashboards_{context}"]

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -163,7 +163,7 @@ parameter_defaults:
         collectd::plugin::virt::hostname_format: name uuid hostname
 ---
 
-. Verify that the dashboards installed correctly:
+. Verify that the dashboards are available:
 +
 [source,bash]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -162,7 +162,6 @@ parameter_defaults:
     ExtraConfig:
         collectd::plugin::virt::hostname_format: name uuid hostname
 ---
-If not added, no data will show in affected panels. 
 
 . Verify that the dashboards installed correctly:
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -189,7 +189,7 @@ grafana-route-service-telemetry.apps.infra.watch
 ----
 +
 
-. Navigate to https://<GRAFANA-ROUTE-ADDRESS> in a web browser. Replace <GRAFANA-ROUTE-ADDRESS> with the value retrieved in the previous step.
+. Navigate to https://<GRAFANA-ROUTE-ADDRESS> in a web browser. Replace <GRAFANA-ROUTE-ADDRESS> with the value that you retrieved in the previous step.
 
 . To view the dashboard, click *Dashboards* and *Manage*.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -155,13 +155,15 @@ $ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/dep
 grafanadashboard.integreatly.org/rhos-cloud-dashboard created
 ----
 [WARNING]
+====
 Some panels in the cloud dashboard require the collect virt plugin hostname_format to be set to `name uuid hostname` in the stf-connectors.yaml. If not configured, affected dashboards will remain empty.
 [source,yaml]
----
+----
 parameter_defaults:
     ExtraConfig:
         collectd::plugin::virt::hostname_format: name uuid hostname
----
+----
+====
 
 . Verify that the dashboards are available:
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -156,7 +156,7 @@ grafanadashboard.integreatly.org/rhos-cloud-dashboard created
 ----
 [WARNING]
 ====
-Some panels in the cloud dashboard require the collect virt plugin hostname_format to be set to `name uuid hostname` in the stf-connectors.yaml. If not configured, affected dashboards will remain empty.
+Some panels in the cloud dashboard require that you set the collectd `virt` plugin parameter `hostname_format` to `name uuid hostname` in the stf-connectors.yaml. If you do not configure this parameter, affected dashboards remain empty.
 [source,yaml]
 ----
 parameter_defaults:

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -72,7 +72,7 @@ grafana-operator.v3.2.0             Grafana Operator                            
 ...
 ----
 
-. To launch a Grafana instance, create or modify the `ServiceTelemetry` object. Set `graphing.enabled` to `true`.
+. To launch a Grafana instance, create or modify the `ServiceTelemetry` object. Set `graphing.enabled` and `graphing.grafana.ingressEnabled` to `true`.
 +
 ----
 $ oc edit stf default
@@ -87,6 +87,8 @@ spec:
   ...
   graphing:
     enabled: true
+    grafana:
+      ingressEnabled: true
 ----
 
 . Verify that the Grafana instance deployed:
@@ -101,8 +103,29 @@ NAME                                  READY   STATUS    RESTARTS   AGE
 grafana-deployment-7fc7848b56-sbkhv   1/1     Running   0          1m
 ----
 
+. Verify the grafana datasources installed correctly:
++
+[source,bash]
+----
+$ oc get grafanadatasources
+----
++
+----
+NAME                    AGE
+default-datasources     20h
+----
 
-
+. Verify the grafana route exists:
++
+[source,bash]
+----
+$ oc get route grafana-route
+----
++
+----
+NAME            HOST/PORT                                                                   PATH   SERVICES          PORT   TERMINATION   WILDCARD
+grafana-route   grafana-route-service-telemetry.apps.ocp46stf.lab.upshift.rdu2.redhat.com          grafana-service   3000   edge          None
+----
 
 [id="importing-dashboards_{context}"]
 = Importing dashboards
@@ -111,7 +134,7 @@ The Grafana Operator can import and manage dashboards by creating `GrafanaDashbo
 
 .Procedure
 
-. Import a dashboard:
+. Import the infrastructure dashboard:
 +
 [source,bash,options="nowrap"]
 ----
@@ -121,8 +144,27 @@ $ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/dep
 ----
 grafanadashboard.integreatly.org/rhos-dashboard created
 ----
+. Import the cloud dashboard:
++
+[source,bash,options="nowrap"]
+----
+$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/rhos-cloud-dashboard.yaml
+----
++
+----
+grafanadashboard.integreatly.org/rhos-cloud-dashboard created
+----
+[WARNING]
+Some panels in the cloud dashboard require the following configuration in the stf-connectors.yaml:
+[source,yaml]
+---
+parameter_defaults:
+    ExtraConfig:
+        collectd::plugin::virt::hostname_format: name uuid hostname
+---
+If not added, no data will show in affected panels. 
 
-. Verify that the resources installed correctly:
+. Verify that the dashboards installed correctly:
 +
 [source,bash]
 ----
@@ -130,44 +172,25 @@ $ oc get grafanadashboards
 ----
 +
 ----
-NAME             AGE
-rhos-dashboard   7d21h
-----
-+
-[source,bash]
-----
-$ oc get grafanadatasources
-----
-+
-----
-NAME                    AGE
-default-ds-prometheus   20h
-----
-
-. Expose the grafana service as a route:
-+
-[source,bash,options="nowrap"]
-----
-$ oc create route edge dashboards --service=grafana-service --insecure-policy="Redirect" --port=3000
+NAME                   AGE
+rhos-dashboard         7d21h
+rhos-cloud-dashboard   7d21h
 ----
 
 . Retrieve the Grafana route address:
-
 +
 [source,bash]
 ----
-$ oc get route dashboards
+$ oc get route grafana-route -ojsonpath='{.spec.host}' 
 ----
 +
 [source,bash,options="nowrap"]
 ----
-NAME         HOST/PORT                                                                    PATH   SERVICES          PORT   TERMINATION     WILDCARD
-dashboards   dashboards-service-telemetry.apps.stfcloudops1.lab.upshift.rdu2.redhat.com          grafana-service   3000   edge/Redirect   None
+grafana-route-service-telemetry.apps.ocp46stf.lab.upshift.rdu2.redhat.com
 ----
 +
-The `HOST/PORT` value is the Grafana route address.
 
-. Navigate to https://<GRAFANA-ROUTE-ADDRESS> in a web browser. Replace <GRAFANA-ROUTE-ADDRESS> with the `HOST/PORT` value that you retrieved in the previous step.
+. Navigate to https://<GRAFANA-ROUTE-ADDRESS> in a web browser. Replace <GRAFANA-ROUTE-ADDRESS> with the value retrieved in the previous step.
 
 . To view the dashboard, click *Dashboards* and *Manage*.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -103,7 +103,7 @@ NAME                                  READY   STATUS    RESTARTS   AGE
 grafana-deployment-7fc7848b56-sbkhv   1/1     Running   0          1m
 ----
 
-. Verify the grafana datasources installed correctly:
+. Verify the Grafana data sources installed correctly:
 +
 [source,bash]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -115,7 +115,7 @@ NAME                    AGE
 default-datasources     20h
 ----
 
-. Verify the grafana route exists:
+. Verify the Grafana route exists:
 +
 [source,bash]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -155,7 +155,7 @@ $ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/dep
 grafanadashboard.integreatly.org/rhos-cloud-dashboard created
 ----
 [WARNING]
-Some panels in the cloud dashboard require the following configuration in the stf-connectors.yaml:
+Some panels in the cloud dashboard require specific values be configured for the collectd virt plugin hostname_format parameter in the stf-connectors.yaml. If not configured some panels in the dashboard will be affected.
 [source,yaml]
 ---
 parameter_defaults:

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -103,7 +103,7 @@ NAME                                  READY   STATUS    RESTARTS   AGE
 grafana-deployment-7fc7848b56-sbkhv   1/1     Running   0          1m
 ----
 
-. Verify the Grafana data sources installed correctly:
+. Verify that the Grafana data sources installed correctly:
 +
 [source,bash]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -185,7 +185,7 @@ $ oc get route grafana-route -ojsonpath='{.spec.host}'
 +
 [source,bash,options="nowrap"]
 ----
-grafana-route-service-telemetry.apps.ocp46stf.lab.upshift.rdu2.redhat.com
+grafana-route-service-telemetry.apps.infra.watch
 ----
 +
 


### PR DESCRIPTION
These instructions are for OSP16.1+

Reorganized the deployment instructions so that steps involved in deployment of the grafana operator using the STO are verified in the same section separately from the section showing how to deploy the dashboards.

Added mention of the rhos-cloud-dashboard and deployment instructions. Implemented warning that the following configuration is required in stf-connectors.yaml for this dashboard to fully function:
```yaml
parameter_defaults:
    ExtraConfig:
        collectd::plugin::virt::hostname_format: name uuid hostname
```