### PR TITLE
Migrate to proper OperatorHub.io index image path

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_enabling-the-operatorhub-io-community-catalog-source.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_enabling-the-operatorhub-io-community-catalog-source.adoc
@@ -45,7 +45,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: quay.io/operator-framework/upstream-community-operators:latest
+  image: quay.io/operatorhubio/catalog:latest
   displayName: OperatorHub.io Operators
   publisher: OperatorHub.io
 EOF


### PR DESCRIPTION
Migrate to the newer OperatorHub.io index image path. The old image path is known to have
issues on OCP 4.6 and later. This change should be compatible with OCP 4.5 and later.
