### PR TITLE
Include enable-stf.yaml for simplified config

### DIFF
--- a/doc-Service-Telemetry-Framework/Makefile
+++ b/doc-Service-Telemetry-Framework/Makefile
@@ -45,10 +45,10 @@ $(IMAGES_TS): $(IMAGES)
 	touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES)
-	asciidoctor --failure-level WARN -a build=$(BUILD) -b xhtml5 -d book -o $@ $<
+	asciidoctor -a source-highlighter=highlightjs -a highlightjs-languages="yaml,bash" -a highlightjs-theme="monokai" --failure-level WARN -a build=$(BUILD) -b xhtml5 -d book -o $@ $<
 
 $(DEST_HTML_13): $(SOURCES)
-	asciidoctor --failure-level WARN -a build=$(BUILD) -a vernum=13 -b xhtml5 -d book -o $@ $<
+	asciidoctor -a source-highlighter=highlightjs -a highlightjs-languages="yaml,bash" -a highlightjs-theme="monokai" --failure-level WARN -a build=$(BUILD) -a vernum=13 -b xhtml5 -d book -o $@ $<
 
 $(DEST_PDF): $(SOURCES) $(IMAGES)
 	asciidoctor-pdf -a build=$(BUILD) -d book -o $@ $<

--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -1,6 +1,9 @@
 = Service Telemetry Framework 1.3
 OpenStack Documentation Team <rhos-docs@redhat.com>
 :imagesdir: images
+:source-highlighter: highlightjs
+:highlightjs-languages: yaml,bash
+:highlightjs-theme: monokai
 :vernum: 16.1
 :toc: left
 :icons: font

--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -1,9 +1,6 @@
 = Service Telemetry Framework 1.3
 OpenStack Documentation Team <rhos-docs@redhat.com>
 :imagesdir: images
-:source-highlighter: highlightjs
-:highlightjs-languages: yaml,bash
-:highlightjs-theme: monokai
 :vernum: 16.1
 :toc: left
 :icons: font

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -13,7 +13,7 @@ To send metrics to {Project} ({ProjectShort}} and Gnocchi simultaneously, you mu
 . Create an environment file named `gnocchi-connectors.yaml` in the
 `/home/stack` directory.
 +
-[source,yaml]
+[source,yaml,options="nowrap",subs="none"]
 ----
 resource_registry:
     OS::TripleO::Services::GnocchiApi: /usr/share/openstack-tripleo-heat-templates/deployment/gnocchi/gnocchi-api-container-puppet.yaml
@@ -40,20 +40,20 @@ parameter_defaults:
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----
-$ openstack overcloud deploy <other-arguments>
-  --templates /usr/share/openstack-tripleo-heat-templates \
+openstack overcloud deploy <other arguments>
+--templates /usr/share/openstack-tripleo-heat-templates \
   --environment-file <...other-environment-files...> \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
-  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/enable-stf.yaml \
+  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-write-qdr.yaml \
+  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml \
+  --environment-file /home/stack/enable-stf.yaml \
   --environment-file /home/stack/stf-connectors.yaml \
   --environment-file /home/stack/gnocchi-connectors.yaml
 ----
 
-. Verification: To verify that the configuration was successful, verify the content
-of the file `/var/lib/config-data/puppet-generated/ceilometer/etc/ceilometer/pipeline.yaml` on a Controller
-node:
-
-[source,yaml]
+. To verify that the configuration was successful, verify the content of the file `/var/lib/config-data/puppet-generated/ceilometer/etc/ceilometer/pipeline.yaml` on a Controller node. Ensure that the `publishers` section of the file contains information for both notifier and Gnocchi.
++
+[source,yaml,options="nowrap",subs="+quotes"]
 ----
 sources:
     - name: meter_source
@@ -67,5 +67,3 @@ sinks:
           - gnocchi://?filter_project=service&archive_policy=high
           - notifier://172.17.1.35:5666/?driver=amqp&topic=metering
 ----
-+
-Ensure that the `publishers` section of the file contains information for both notifier and Gnocchi.

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -40,7 +40,7 @@ parameter_defaults:
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----
-openstack overcloud deploy <other arguments>
+$ openstack overcloud deploy _<other_arguments>_
 --templates /usr/share/openstack-tripleo-heat-templates \
   --environment-file <...other-environment-files...> \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-gnocchi-metrics.adoc
@@ -1,3 +1,4 @@
+[id="sending-metrics-to-gnocchi-and-to-stf_{context}"]
 = Sending metrics to Gnocchi and to {ProjectShort}
 
 [role="_abstract"]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -260,7 +260,7 @@ Deploy or update the overcloud with the required environment files to result in 
 +
 * the `enable-stf.yaml` environment file to ensure defaults are set up correctly
 * the `stf-connectors.yaml` environment file to define the connection to {ProjectShort}
-* the `collectd-write-qdr.yaml` file that ensures that collectd telemetry and events are sent to {ProjectShort}
+* the `collectd-write-qdr.yaml` file to ensure that collectd telemetry and events are sent to {ProjectShort}
 * the `ceilometer-write-qdr.yaml` file that ensures that Ceilometer telemetry and events are sent to {ProjectShort}
 * the `qdr-edge-only.yaml` file that ensures the message bus is enabled and connected to {ProjectShort} message bus routers
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -29,7 +29,9 @@ To configure the {OpenStack} overcloud, you must configure the data collection a
 To configure the {OpenStack} overcloud, complete the following tasks:
 
 . xref:retrieving-the-qdr-route-address[]
+. xref:configuring-the-enable-stf-for-the-overcloud[]
 . xref:configuring-the-stf-connection-for-the-overcloud[]
+. xref:deploying-the-overcloud[]
 . xref:validating-clientside-installation_assembly-completing-the-stf-configuration[]
 
 ifdef::include_when_16_1[]
@@ -59,10 +61,145 @@ default-interconnect-5671-service-telemetry.apps.infra.watch
 [NOTE]
 If your {ProjectShort} installation differs from the documentation, ensure that you retrieve the correct {MessageBus} route address.
 
+[[configuring-the-enable-stf-for-the-overcloud]]
+== Creating the base configuration for {ProjectShort}
+
+To configure the base parameters to provide a compatible data collection and transport for {ProjectShort}, you must create a file that defines the default data collection values.
+
+.Procedure
+
+. Log in to the {OpenStack} undercloud as the `stack` user.
+
+. Create a configuration file called `enable-stf.yaml` in the `/home/stack` directory.
++
+ifdef::include_when_13[]
+[source,yaml,options="nowrap",subs="+quotes"]
+----
+parameter_defaults:
+    # only send to STF, not other publishers
+    EventPipelinePublishers: []
+    PipelinePublishers: []
+
+    # manage the polling and pipeline configuration files for Ceilometer agents
+    ManagePolling: true
+    ManagePipeline: true
+
+    # enable Ceilometer metrics and events
+    CeilometerQdrPublishMetrics: true
+    CeilometerQdrPublishEvents: true
+
+    # set collectd overrides for higher telemetry resolution and extra plugins
+    # to load
+    CollectdConnectionType: amqp1
+    CollectdAmqpInterval: 5
+    CollectdDefaultPollingInterval: 5
+    CollectdExtraPlugins:
+    - vmem
+
+    ExtraConfig:
+        ceilometer::agent::polling::polling_interval: 30
+        ceilometer::agent::polling::polling_meters:
+        - cpu
+        - disk.*
+        - ip.*
+        - image.*
+        - memory
+        - memory.*
+        - network.*
+        - perf.*
+        - port
+        - port.*
+        - switch
+        - switch.*
+        - storage.*
+        - volume.*
+
+        # to avoid filling the memory buffers if disconnected from the message bus
+        collectd::plugin::amqp1::send_queue_limit: 50
+
+        # receive extra information about virtual memory
+        collectd::plugin::vmem::verbose: true
+
+        # provide the human-friendly name of the virtual instance
+        collectd::plugin::virt::plugin_instance_format: metadata
+----
+endif::include_when_13[]
+ifdef::include_when_16[]
+[source,yaml,options="nowrap",subs="+quotes"]
+----
+parameter_defaults:
+    # only send to STF, not other publishers
+    EventPipelinePublishers: []
+    PipelinePublishers: []
+
+    # manage the polling and pipeline configuration files for Ceilometer agents
+    ManagePolling: true
+    ManagePipeline: true
+
+    # required to set valid parameter due to typo in ceilometer-write-qdr.yaml 
+    # and will be resolved in a future release
+    CeilometerQdrPublishMetrics: true
+
+    # enable collection of API status
+    CollectdEnableSensubility: true
+    CollectdSensubilityTransport: amqp1
+
+    # enable collection of containerized service metrics
+    CollectdEnableLibpodstats: true
+
+    # set collectd overrides for higher telemetry resolution and extra plugins
+    # to load
+    CollectdConnectionType: amqp1
+    CollectdAmqpInterval: 5
+    CollectdDefaultPollingInterval: 5
+    CollectdExtraPlugins:
+    - vmem
+
+    ExtraConfig:
+        ceilometer::agent::polling::polling_interval: 30
+        ceilometer::agent::polling::polling_meters:
+        - cpu
+        - disk.*
+        - ip.*
+        - image.*
+        - memory
+        - memory.*
+        - network.*
+        - perf.*
+        - port
+        - port.*
+        - switch
+        - switch.*
+        - storage.*
+        - volume.*
+
+        # to avoid filling the memory buffers if disconnected from the message bus
+        collectd::plugin::amqp1::send_queue_limit: 50
+
+        # receive extra information about virtual memory
+        collectd::plugin::vmem::verbose: true
+
+        # provide name and uuid in addition to hostname for better correlation
+        # to ceilometer data
+        collectd::plugin::virt::hostname_format: "name uuid hostname"
+
+        # provide the human-friendly name of the virtual instance
+        collectd::plugin::virt::plugin_instance_format: metadata
+
+        # set memcached collectd plugin to report its metrics by hostname
+        # rather than host IP, ensuring metrics in the dashboard remain uniform
+        collectd::plugin::memcached::instances:
+          local:
+            host: "%{hiera('fqdn_canonical')}"
+            port: 11211
+----
+endif::include_when_16[]
+
+
 [[configuring-the-stf-connection-for-the-overcloud]]
 == Configuring the {ProjectShort} connection for the overcloud
 
-To configure the {ProjectShort} connection, you must create a file that contains the connection configuration of the {MessageBus} for the overcloud to the {ProjectShort} deployment. Enable the collection of events and storage of the events in {ProjectShort} and deploy the overcloud.
+To configure the {ProjectShort} connection, you must create a file that contains the connection configuration of the {MessageBus} for the overcloud to the {ProjectShort} deployment. Enable the collection of events and storage of the events in {ProjectShort} and deploy the overcloud. The configuration is set up for a single cloud instance with the default message bus topics. For configuration of multiple cloud deployments, see xref:configuring-multiple-clouds_assembly-advanced-features[].
 
 .Procedure
 
@@ -74,117 +211,59 @@ To configure the {ProjectShort} connection, you must create a file that contains
 ====
 The Service Telemetry Operator simplifies the deployment of all data ingestion and data storage components for single cloud deployments. To share the data storage domain with multiple clouds, see xref:configuring-multiple-clouds_assembly-advanced-features[].
 
-Additionally, setting `EventPipelinePublishers` and `PipelinePublishers` to empty lists results in no metric or event data passing to {OpenStack} legacy telemetry components, such as Gnocchi or Panko. If you need to send data to additional pipelines, the Ceilometer polling interval of 5 seconds as specified in `ExtraConfig` might overwhelm the legacy components. If you configure a longer polling interval, you must also modify {ProjectShort} to avoid stale metrics, resulting in what appears to be missing data in Prometheus.
-
-If an adjustment needs to be made to the polling interval, then modify the ServiceTelemetry object `backends.metrics.prometheus.scrapeInterval` parameter from the default value of `10s` to double the polling interval of the data collectors. For example, if `CollectdAmqpInterval` and `ceilometer::agent::polling::polling_interval` are adjusted to `30` then set the `backends.metrics.prometheus.scrapeInterval` to a value of `60s`.
+Additionally, setting `EventPipelinePublishers` and `PipelinePublishers` to empty lists results in no metric or event data passing to {OpenStack} legacy telemetry components, such as Gnocchi or Panko. If you need to send data to additional pipelines, the Ceilometer polling interval of 30 seconds as specified in `ExtraConfig` might overwhelm the legacy components.
 ====
 
 . In the `stf-connectors.yaml` file, configure the `MetricsQdrConnectors` address to connect the {MessageBus} on the overcloud to the {ProjectShort} deployment.
-* Add the `CeilometerQdrPublishMetrics: true` parameter to enable collection and transport of Ceilometer metrics to {ProjectShort}.
-* Add the `CeilometerQdrPublishEvents: true` parameter to enable collection and transport of Ceilometer events to {ProjectShort}.
-* Add the `EventPiplinePublishers: []` and `PipelinePublishers: []` to avoid writing data to Gnocchi and Panko.
-* Add the `ManagePolling: true` and `ManagePipeline: true` parameters to allow full control of Ceilometer polling and pipeline configuration.
-* Add the `ExtraConfig` parameter `ceilometer::agent::polling::polling_interval` to set the polling interval of Ceilometer to be compatible with the default {ProjectShort} scrape interval.
 * Replace the `host` parameter with the value of `HOST/PORT` that you retrieved in xref:retrieving-the-qdr-route-address[]:
 +
 ifdef::include_when_13[]
-[source,yaml]
+[source,yaml,options="nowrap",subs="+quotes"]
 ----
 parameter_defaults:
-    EventPipelinePublishers: []
-    PipelinePublishers: []
-    CeilometerEnablePanko: false
-    CeilometerQdrPublishEvents: true
-    CeilometerQdrPublishMetrics: true
-    ManagePipeline: true
-    ManagePolling: true
-    CollectdAmqpInstances:
-        notify:
-            format: JSON
-            notify: true
-            presettle: false
-        telemetry:
-            format: JSON
-            presettle: false
-    CollectdAmqpInterval: 5
-    CollectdConnectionType: amqp1
-    CollectdDefaultPlugins:
-    - cpu
-    - df
-    - disk
-    - hugepages
-    - interface
-    - load
-    - memory
-    - processes
-    - unixsock
-    - uptime
-    - connectivity
-    - intel_rdt
-    - ipmi
-    - procevent
-    CollectdDefaultPollingInterval: 5
-    MetricsQdrAddresses:
-    -   distribution: multicast
-        prefix: collectd
-    -   distribution: multicast
-        prefix: anycast/ceilometer
     MetricsQdrConnectors:
-    -   host: default-interconnect-5671-service-telemetry.apps.infra.watch
-        port: 443
-        role: edge
-        sslProfile: sslProfile
-        verifyHostname: false
+    - host: default-interconnect-5671-service-telemetry.apps.stf.cloudops.psi.redhat.com
+      port: 443
+      role: edge
+      sslProfile: sslProfile
+      verifyHostname: false
+
     MetricsQdrSSLProfiles:
-ifdef::include_when_13[]
     -   name: sslProfile
         caCertFileContent: |
           ----BEGIN CERTIFICATE----
           <snip>
           ----END CERTIFICATE----
-endif::include_when_13[]
-    ExtraConfig:
-        collectd::plugin::cpu::reportbycpu: true
-        collectd::plugin::cpu::reportbystate: true
-        collectd::plugin::cpu::reportnumcpu: false
-        collectd::plugin::cpu::valuespercentage: true
-        collectd::plugin::df::ignoreselected: true
-        collectd::plugin::df::reportbydevice: true
-        collectd::plugin::df::fstypes: ['xfs']
-        collectd::plugin::load::reportrelative: true
-        collectd::plugin::virt::connection: "qemu:///system"
-        collectd::plugin::virt::extra_stats: "cpu_util disk disk_err pcpu job_stats_background perf vcpupin"
-        collectd::plugin::virt::hostname_format: "hostname"
-        ceilometer::agent::polling::polling_interval: 5
 ----
 endif::include_when_13[]
 ifdef::include_when_16[]
-[source,yaml]
+[source,yaml,options="nowrap",subs="+quotes"]
 ----
 parameter_defaults:
-    EventPipelinePublishers: []
-    PipelinePublishers: []
-    CeilometerQdrPublishEvents: true
-    CeilometerQdrPublishMetrics: true
     MetricsQdrConnectors:
     - host: default-interconnect-5671-service-telemetry.apps.infra.watch
       port: 443
       role: edge
       sslProfile: sslProfile
       verifyHostname: false
-    ExtraConfig:
-      ceilometer::agent::polling::polling_interval: 5
 ----
 endif::include_when_16[]
 
-. Add the following files to your {OpenStack} {OpenStackInstaller} deployment to setup collectd and {MessageBus}:
+[[deploying-the-overcloud]]
+== Deploying the overcloud
+
+Deploy or update the overcloud with the required environment files to result in data being collected and transmitted to {ProjectShort}.
+
+.Procedure
+
+. Add the following files to your {OpenStack} {OpenStackInstaller} deployment to setup data collection and {MessageBus}:
 +
-* the `stf-connectors.yaml` environment file
-ifdef::include_when_16[* the `enable-stf.yaml` file that ensures that the environment is being used during the overcloud deployment]
-ifdef::include_when_13[* the `collectd-write-qdr.yaml` file that ensures that collectd telemetry is sent to {ProjectShort}]
-* the `ceilometer-write-qdr.yaml` file that ensures that Ceilometer telemetry is sent to {ProjectShort}
+* the `enable-stf.yaml` environment file to ensure defaults are set up correctly
+* the `stf-connectors.yaml` environment file to define the connection to {ProjectShort}
+* the `collectd-write-qdr.yaml` file that ensures that collectd telemetry and events are sent to {ProjectShort}
+* the `ceilometer-write-qdr.yaml` file that ensures that Ceilometer telemetry and events are sent to {ProjectShort}
+* the `qdr-edge-only.yaml` file that ensures the message bus is enabled and connected to {ProjectShort} message bus routers
 +
-ifdef::include_when_13[]
 [source,bash,options="nowrap",subs="+quotes"]
 ----
 openstack overcloud deploy <other arguments>
@@ -193,19 +272,8 @@ openstack overcloud deploy <other arguments>
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-write-qdr.yaml \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml \
+  --environment-file /home/stack/enable-stf.yaml \
   --environment-file /home/stack/stf-connectors.yaml
 ----
-endif::include_when_13[]
-ifdef::include_when_16[]
-[source,bash,options="nowrap",subs="+quotes"]
-----
-openstack overcloud deploy <other arguments>
-  --templates /usr/share/openstack-tripleo-heat-templates \
-  --environment-file <...other-environment-files...> \
-  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
-  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/enable-stf.yaml \
-  --environment-file /home/stack/stf-connectors.yaml
-----
-endif::include_when_16[]
 
 . Deploy the {OpenStack} overcloud.

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -261,7 +261,7 @@ Deploy or update the overcloud with the required environment files to result in 
 * the `enable-stf.yaml` environment file to ensure defaults are set up correctly
 * the `stf-connectors.yaml` environment file to define the connection to {ProjectShort}
 * the `collectd-write-qdr.yaml` file to ensure that collectd telemetry and events are sent to {ProjectShort}
-* the `ceilometer-write-qdr.yaml` file that ensures that Ceilometer telemetry and events are sent to {ProjectShort}
+* the `ceilometer-write-qdr.yaml` file to ensure that Ceilometer telemetry and events are sent to {ProjectShort}
 * the `qdr-edge-only.yaml` file that ensures the message bus is enabled and connected to {ProjectShort} message bus routers
 +
 [source,bash,options="nowrap",subs="+quotes"]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -266,7 +266,7 @@ Deploy or update the overcloud with the required environment files to result in 
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----
-openstack overcloud deploy <other arguments>
+$ openstack overcloud deploy <other arguments>
 --templates /usr/share/openstack-tripleo-heat-templates \
   --environment-file <...other-environment-files...> \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -61,7 +61,7 @@ default-interconnect-5671-service-telemetry.apps.infra.watch
 [NOTE]
 If your {ProjectShort} installation differs from the documentation, ensure that you retrieve the correct {MessageBus} route address.
 
-[[configuring-the-enable-stf-for-the-overcloud]]
+[[creating-the-base-configuration-for-stf]]
 == Creating the base configuration for {ProjectShort}
 
 To configure the base parameters to provide a compatible data collection and transport for {ProjectShort}, you must create a file that defines the default data collection values.

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -262,7 +262,7 @@ Deploy or update the overcloud with the required environment files to result in 
 * the `stf-connectors.yaml` environment file to define the connection to {ProjectShort}
 * the `collectd-write-qdr.yaml` file to ensure that collectd telemetry and events are sent to {ProjectShort}
 * the `ceilometer-write-qdr.yaml` file to ensure that Ceilometer telemetry and events are sent to {ProjectShort}
-* the `qdr-edge-only.yaml` file that ensures the message bus is enabled and connected to {ProjectShort} message bus routers
+* the `qdr-edge-only.yaml` file to ensure that the message bus is enabled and connected to {ProjectShort} message bus routers
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -29,7 +29,7 @@ To configure the {OpenStack} overcloud, you must configure the data collection a
 To configure the {OpenStack} overcloud, complete the following tasks:
 
 . xref:retrieving-the-qdr-route-address[]
-. xref:configuring-the-enable-stf-for-the-overcloud[]
+. xref:creating-the-base-configuration-for-stf[]
 . xref:configuring-the-stf-connection-for-the-overcloud[]
 . xref:deploying-the-overcloud[]
 . xref:validating-clientside-installation_assembly-completing-the-stf-configuration[]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -72,6 +72,13 @@ To configure the base parameters to provide a compatible data collection and tra
 
 . Create a configuration file called `enable-stf.yaml` in the `/home/stack` directory.
 +
+[IMPORTANT]
+====
+Setting `EventPipelinePublishers` and `PipelinePublishers` to empty lists results in no event or metric data passing to {OpenStack} legacy telemetry components, such as Gnocchi or Panko. If you need to send data to additional pipelines, the Ceilometer polling interval of 30 seconds as specified in `ExtraConfig` might overwhelm the legacy components, and should be increased to a larger value such as `300`. Increasing the value to a longer polling interval will result in less telemetry resolution in {ProjectShort}.
+
+To enable collection of telemetry with {ProjectShort} and Gnocchi, see xref:sending-metrics-to-gnocchi-and-to-stf_assembly-completing-the-stf-configuration[]
+====
++
 ifdef::include_when_13[]
 [source,yaml,options="nowrap",subs="+quotes"]
 ----
@@ -206,13 +213,6 @@ To configure the {ProjectShort} connection, you must create a file that contains
 . Log in to the {OpenStack} undercloud as the `stack` user.
 
 . Create a configuration file called `stf-connectors.yaml` in the `/home/stack` directory.
-+
-[IMPORTANT]
-====
-The Service Telemetry Operator simplifies the deployment of all data ingestion and data storage components for single cloud deployments. To share the data storage domain with multiple clouds, see xref:configuring-multiple-clouds_assembly-advanced-features[].
-
-Additionally, setting `EventPipelinePublishers` and `PipelinePublishers` to empty lists results in no metric or event data passing to {OpenStack} legacy telemetry components, such as Gnocchi or Panko. If you need to send data to additional pipelines, the Ceilometer polling interval of 30 seconds as specified in `ExtraConfig` might overwhelm the legacy components.
-====
 
 . In the `stf-connectors.yaml` file, configure the `MetricsQdrConnectors` address to connect the {MessageBus} on the overcloud to the {ProjectShort} deployment.
 * Replace the `host` parameter with the value of `HOST/PORT` that you retrieved in xref:retrieving-the-qdr-route-address[]:
@@ -258,11 +258,11 @@ Deploy or update the overcloud with the required environment files to result in 
 
 . Add the following files to your {OpenStack} {OpenStackInstaller} deployment to setup data collection and {MessageBus}:
 +
-* the `enable-stf.yaml` environment file to ensure defaults are set up correctly
-* the `stf-connectors.yaml` environment file to define the connection to {ProjectShort}
 * the `collectd-write-qdr.yaml` file to ensure that collectd telemetry and events are sent to {ProjectShort}
 * the `ceilometer-write-qdr.yaml` file to ensure that Ceilometer telemetry and events are sent to {ProjectShort}
 * the `qdr-edge-only.yaml` file to ensure that the message bus is enabled and connected to {ProjectShort} message bus routers
+* the `enable-stf.yaml` environment file to ensure defaults are set up correctly
+* the `stf-connectors.yaml` environment file to define the connection to {ProjectShort}
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
@@ -204,8 +204,10 @@ endif::include_when_16[]
 <3> Define the topic for collectd events. This value is the format of `collectd/cloud1-notify`.
 <4> Define the topic for collectd metrics. This value is the format of `collectd/cloud1-telemetry`.
 <5> Define the topic for collectd-sensubility events. This should be the exact string format of `collectd/cloud1-notify`
+ifdef::include_when_16[]
 <6> Adjust the `MetricsQdrConnectors` host to the address of the {ProjectShort} route.
 <7> Enable monitoring of health and API status.
+endif::include_when_16[]
 +
 . Ensure that the naming convention in the `stf-connectors.yaml` file aligns with the `spec.amqpUrl` field in the Smart Gateway configuration. For example, configure the `CeilometerQdrEventsConfig.topic` field to a value of `cloud1-event`.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
@@ -29,17 +29,10 @@ To label traffic according to the cloud of origin, you must create a configurati
 [NOTE]
 If you enabled container health and API status monitoring, you must also modify the `CollectdSensubilityResultsChannel` parameter. For more information, see xref:monitoring-container-health-and-api-status_assembly-advanced-features[].
 
-
-[WARNING]
-Remove
-ifdef::include_when_16[]
-`enable-stf.yaml` and
-endif::include_when_16[]
-`ceilometer-write-qdr.yaml` environment file references from your overcloud deployment. This configuration is redundant and results in duplicate information being sent from each cloud node.
-
 .Prerequisites
 
 * You have created a unique domain name environment file. For more information, see xref:setting-a-unique-cloud-domain_assembly-advanced-features[].
+* You have created the `enabled-stf.yaml` to set environment defaults for {ProjectShort}.
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_deleting-the-default-smart-gateways.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deleting-the-default-smart-gateways.adoc
@@ -32,11 +32,11 @@ WARNING: The `cloudsRemoveOnMissing` parameter is disabled by default. If you en
 
 .Procedure
 
-
 . Define your `clouds` parameter with the list of cloud objects to be managed by the Service Telemetry Operator. For more information, see xref:clouds_assembly-installing-the-core-components-of-stf[].
 
 . Edit the ServiceTelemetry object and add the `cloudsRemoveOnMissing` parameter:
 +
+[source,yaml]
 ----
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
@@ -53,6 +53,7 @@ spec:
 
 . Verify that the Operator deleted the Smart Gateways. This can take several minutes while the Operators reconcile the changes:
 +
+[source,bash]
 ----
 $ oc get smartgateways
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -47,16 +47,19 @@ When you deploy {ProjectShort} for the first time, Smart Gateway manifests are c
 . Log in to {OpenShift}.
 . Change to the `service-telemetry` namespace:
 +
+[source,bash]
 ----
 $ oc project service-telemetry
 ----
 
 . Edit the `default` ServiceTelemetry object and add a `clouds` parameter with your configuration:
 +
+[source,bash]
 ----
 $ oc edit stf default
 ----
 +
+[source,yaml,options="nowrap"]
 ----
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
@@ -87,10 +90,12 @@ spec:
 
 . Verify that each Smart Gateway is running. This can take several minutes depending on the number of Smart Gateways:
 +
+[source,bash]
 ----
 $ oc get po -l app=smart-gateway
 ----
 +
+[source,bash]
 ----
 NAME                                                      READY   STATUS    RESTARTS   AGE
 default-cloud1-ceil-event-smartgateway-6cfb65478c-g5q82   1/1     Running   0          13h

--- a/doc-Service-Telemetry-Framework/modules/proc_monitoring-container-health-and-api-status.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_monitoring-container-health-and-api-status.adoc
@@ -38,12 +38,14 @@ To monitor healthchecks in {Project} ({ProjectShort}), you must enable and confi
 
 . Open the `stf-connectors.yaml` and edit the `collectd-sensubility` parameter:
 +
+[source,yaml]
 ----
 CollectdEnableSensubility: true
 CollectdSensubilityTransport: amqp1
 ----
 . If your environment has multiple clouds, configure the `collectd-sensubility` events channel with the new collectd events address. Edit the `stf-connectors.yaml` file:
 +
+[source,yaml]
 ----
 CollectdSensubilityResultsChannel: collectd/cloudprefix-notify
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_monitoring-resource-usage-of-openstack-services.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_monitoring-resource-usage-of-openstack-services.adoc
@@ -40,6 +40,7 @@ Monitor the resource usage of the {OpenStack} services, such as the APIs and oth
 
 . Add the following configuration to `parameter_defaults`:
 +
+[source,yaml]
 ----
   CollectdEnableLibpodstats: true
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-a-unique-cloud-domain.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-a-unique-cloud-domain.adoc
@@ -32,12 +32,12 @@ To ensure that AMQ router connections from {OpenStack} to {Project} ({ProjectSho
 
 . Set the `CloudDomain` parameter in the environment file, as shown in the following example:
 +
+[source,yaml,options="nowrap"]
 ----
-
-       parameter_defaults:
-              CloudDomain: newyork-west-04
-              CephStorageHostnameFormat: 'ceph-%index%'
-              ObjectStorageHostnameFormat: 'swift-%index%'
-              ComputeHostnameFormat: 'compute-%index%'
+parameter_defaults:
+    CloudDomain: newyork-west-04
+    CephStorageHostnameFormat: 'ceph-%index%'
+    ObjectStorageHostnameFormat: 'swift-%index%'
+    ComputeHostnameFormat: 'compute-%index%'
 ----
 . Add this environment file to your deployment. For more information, see xref:creating-openstack-environment-file_assembly-advanced-features[] and https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/overcloud_parameters/core-overcloud-parameters[Core overcloud parameters] in the _Overcloud Parameters_ guide.

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -122,6 +122,7 @@ default-datasources     20h
 $ oc get route grafana-route
 ----
 +
+[source,bash,options="nowrap"]
 ----
 NAME            HOST/PORT                                          PATH   SERVICES          PORT   TERMINATION   WILDCARD
 grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -35,13 +35,14 @@ Enable OperatorHub.io catalog source for the Grafana Operator. For more informat
 . Log in to {OpenShift}.
 . Change to the `service-telemetry` namespace:
 +
+[source,bash]
 ----
 $ oc project service-telemetry
 ----
 
 . Deploy the Grafana operator:
 +
-[source,bash]
+[source,yaml]
 ----
 $ oc apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
@@ -63,10 +64,7 @@ EOF
 [source,bash,options="nowrap",subs="+quotes"]
 ----
 $ oc get csv
-----
-+
-[source,bash,options="nowrap"]
-----
+
 NAME                                DISPLAY                                         VERSION   REPLACES                            PHASE
 grafana-operator.v3.2.0             Grafana Operator                                3.2.0                                         Succeeded
 ...
@@ -74,12 +72,10 @@ grafana-operator.v3.2.0             Grafana Operator                            
 
 . To launch a Grafana instance, create or modify the `ServiceTelemetry` object. Set `graphing.enabled` and `graphing.grafana.ingressEnabled` to `true`.
 +
+[source,bash]
 ----
 $ oc edit stf default
-----
-+
-[source,yaml]
-----
+
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 ...
@@ -96,9 +92,7 @@ spec:
 [source,bash]
 ----
 $ oc get pod -l app=grafana
-----
-+
-----
+
 NAME                                  READY   STATUS    RESTARTS   AGE
 grafana-deployment-7fc7848b56-sbkhv   1/1     Running   0          1m
 ----
@@ -108,22 +102,17 @@ grafana-deployment-7fc7848b56-sbkhv   1/1     Running   0          1m
 [source,bash]
 ----
 $ oc get grafanadatasources
-----
-+
-----
+
 NAME                    AGE
 default-datasources     20h
 ----
 
 . Verify the Grafana route exists:
 +
-[source,bash]
-----
-$ oc get route grafana-route
-----
-+
 [source,bash,options="nowrap"]
 ----
+$ oc get route grafana-route
+
 NAME            HOST/PORT                                          PATH   SERVICES          PORT   TERMINATION   WILDCARD
 grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None
 ----
@@ -140,9 +129,7 @@ The Grafana Operator can import and manage dashboards by creating `GrafanaDashbo
 [source,bash,options="nowrap"]
 ----
 $ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/rhos-dashboard.yaml
-----
-+
-----
+
 grafanadashboard.integreatly.org/rhos-dashboard created
 ----
 . Import the cloud dashboard:
@@ -150,9 +137,7 @@ grafanadashboard.integreatly.org/rhos-dashboard created
 [source,bash,options="nowrap"]
 ----
 $ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/rhos-cloud-dashboard.yaml
-----
-+
-----
+
 grafanadashboard.integreatly.org/rhos-cloud-dashboard created
 ----
 [WARNING]
@@ -171,9 +156,7 @@ parameter_defaults:
 [source,bash]
 ----
 $ oc get grafanadashboards
-----
-+
-----
+
 NAME                   AGE
 rhos-dashboard         7d21h
 rhos-cloud-dashboard   7d21h
@@ -181,16 +164,12 @@ rhos-cloud-dashboard   7d21h
 
 . Retrieve the Grafana route address:
 +
-[source,bash]
-----
-$ oc get route grafana-route -ojsonpath='{.spec.host}' 
-----
-+
 [source,bash,options="nowrap"]
 ----
+$ oc get route grafana-route -ojsonpath='{.spec.host}' 
+
 grafana-route-service-telemetry.apps.infra.watch
 ----
-+
 
 . Navigate to https://<GRAFANA-ROUTE-ADDRESS> in a web browser. Replace <GRAFANA-ROUTE-ADDRESS> with the value that you retrieved in the previous step.
 
@@ -216,4 +195,4 @@ $ oc project service-telemetry
 $ oc describe grafana default
 ----
 
-.  To modify the default values of the Grafana administrator username and password through the ServiceTelemetry object, use the `graphing.grafana.adminUser` and `graphing.grafana.adminPassword` parameters.
+. To modify the default values of the Grafana administrator username and password through the ServiceTelemetry object, use the `graphing.grafana.adminUser` and `graphing.grafana.adminPassword` parameters.


### PR DESCRIPTION
Include the use of a new enable-stf.yaml to simplify and split out the
default parameters and values for an OSP installation using STF. This
makes the stf-connectors.yaml simpler to configure, and makes both OSP13
and OSP16 overcloud deployment procedure the same.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
