### PR TITLE
Align OSP13 base configuration for STF (#225)

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -90,6 +90,24 @@ parameter_defaults:
 
         # provide the human-friendly name of the virtual instance
         collectd::plugin::virt::plugin_instance_format: metadata
+
+        # set memcached collectd plugin to report its metrics by hostname
+        # rather than host IP, ensuring metrics in the dashboard remain uniform
+        collectd::plugin::memcached::instances:
+          local:
+            host: "%{hiera(fqdn_canonical)}"
+            port: 11211
+
+        # align defaults across OSP versions
+        collectd::plugin::cpu::reportbycpu: true
+        collectd::plugin::cpu::reportbystate: true
+        collectd::plugin::cpu::reportnumcpu: false
+        collectd::plugin::cpu::valuespercentage: true
+        collectd::plugin::df::ignoreselected: true
+        collectd::plugin::df::reportbydevice: true
+        collectd::plugin::df::fstypes: ['xfs']
+        collectd::plugin::load::reportrelative: true
+        collectd::plugin::virt::extra_stats: "pcpu cpu_util vcpupin vcpu memory disk disk_err disk_allocation disk_capacity disk_physical domain_state job_stats_background perf"
 ----
 endif::include_when_13[]
 ifdef::include_when_16[]


### PR DESCRIPTION
Align the OSP13 base configuration for STF across OSP versions by
setting the same default configuration as OSP16 where not defined.

Cherry picked from commit 931df512300211cfeab4b280251540d507cc1a56

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
