### PR TITLE
Configure sensubility to publish to new address

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -100,7 +100,7 @@ endif::include_when_16[]
 <4> Define the topic for collectd events. This value is the format of `collectd/cloud1-notify`.
 <5> Define the topic for collectd metrics. This value is the format of `collectd/cloud1-telemetry`.
 ifdef::include_when_16[]
-<6> Define the topic for collectd-sensubility events. Ensure that this value is the exact string format `sensubility/cloud1-metrics`
+<6> Define the topic for collectd-sensubility events. Ensure that this value is the exact string format `sensubility/cloud1-telemetry`
 endif::include_when_16[]
 +
 . Ensure that the naming convention in the `stf-connectors.yaml` file aligns with the `spec.bridge.amqpUrl` field in the Smart Gateway configuration. For example, configure the `CeilometerQdrEventsConfig.topic` field to a value of `cloud1-event`.

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -91,7 +91,7 @@ endif::include_when_13[]
             presettle: true
 
 ifdef::include_when_16[]
-    CollectdSensubilityResultsChannel: sensubility/cloud1-metrics # <6>
+    CollectdSensubilityResultsChannel: sensubility/cloud1-telemetry # <6>
 endif::include_when_16[]
 ----
 <1> Replace the `host` parameter with the value of `HOST/PORT` that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -91,7 +91,7 @@ endif::include_when_13[]
             presettle: true
 
 ifdef::include_when_16[]
-    CollectdSensubilityResultsChannel: collectd/cloud1-notify # <6>
+    CollectdSensubilityResultsChannel: sensubility/cloud1-metrics # <6>
 endif::include_when_16[]
 ----
 <1> Replace the `host` parameter with the value of `HOST/PORT` that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
@@ -100,7 +100,7 @@ endif::include_when_16[]
 <4> Define the topic for collectd events. This value is the format of `collectd/cloud1-notify`.
 <5> Define the topic for collectd metrics. This value is the format of `collectd/cloud1-telemetry`.
 ifdef::include_when_16[]
-<6> Define the topic for collectd-sensubility events. Ensure that this value is the exact string format `collectd/cloud1-notify`
+<6> Define the topic for collectd-sensubility events. Ensure that this value is the exact string format `sensubility/cloud1-metrics`
 endif::include_when_16[]
 +
 . Ensure that the naming convention in the `stf-connectors.yaml` file aligns with the `spec.bridge.amqpUrl` field in the Smart Gateway configuration. For example, configure the `CeilometerQdrEventsConfig.topic` field to a value of `cloud1-event`.


### PR DESCRIPTION
As a result of the changes made in https://github.com/infrawatch/sg-core/pull/60, sensubility now must publish metrics at a new QDR address