### PR TITLE
Configure sensubility to publish to new address

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_monitoring-container-health-and-api-status.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_monitoring-container-health-and-api-status.adoc
@@ -41,6 +41,7 @@ To monitor healthchecks in {Project} ({ProjectShort}), you must enable and confi
 ----
 CollectdEnableSensubility: true
 CollectdSensubilityTransport: amqp1
+CollectdSensubilityResultsChannel: collectd/notify
 ----
 . If your environment has multiple clouds, configure the `collectd-sensubility` events channel with the new collectd events address. Edit the `stf-connectors.yaml` file:
 +


### PR DESCRIPTION
For 1.2, sensubility should not publish to a new address. However, because some of the defaults are changing on the OSP side (see https://review.opendev.org/c/openstack/tripleo-heat-templates/+/795608, where the default sensubility publish address is set to `sensubility/metrics`, the original address of  `collectd/notify` must be explicitly set