### PR TITLE
Use the stable tag for STF CatalogSource

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-amq-certificate-manager-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-amq-certificate-manager-operator.adoc
@@ -43,7 +43,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: Red Hat STF Operators
-  image: quay.io/redhat-operators-stf/stf-catalog:v4.6
+  image: quay.io/redhat-operators-stf/stf-catalog:stable
   publisher: Red Hat
   sourceType: grpc
   updateStrategy:


### PR DESCRIPTION
Instead of having a versioned value for stf-catalog index image (which only contains
AMQ Certificate Manager) migrate to using the stable tag instead.
