### PR TITLE
Updates for new sensubility amqp1 address (#239)

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -135,6 +135,7 @@ parameter_defaults:
     # enable collection of API status
     CollectdEnableSensubility: true
     CollectdSensubilityTransport: amqp1
+    CollectdSensubilityResultsChannel: sensubility/telemetry
 
     # enable collection of containerized service metrics
     CollectdEnableLibpodstats: true

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -24,7 +24,12 @@
 = Deploying Smart Gateways
 
 [role="_abstract"]
-You must deploy a Smart Gateway for each of the data collection types for each cloud; one for collectd metrics, one for collectd events, one for Ceilometer metrics, and one for Ceilometer events. Configure each of the Smart Gateways to listen on the AMQP address that you define for the corresponding cloud. Smart Gateways are defined via the `clouds` parameter in the `ServiceTelemetry` manifest.
+ifdef::include_when_16[]
+You must deploy a Smart Gateway for each of the data collection types for each cloud; one for collectd metrics, one for collectd events, one for Ceilometer metrics, one for Ceilometer events, and one for collectd-sensubility metrics. Configure each of the Smart Gateways to listen on the AMQP address that you define for the corresponding cloud. To define Smart Gateways, configure the `clouds` parameter in the `ServiceTelemetry` manifest.
+endif::include_when_16[]
+ifdef::include_when_13[]
+You must deploy a Smart Gateway for each of the data collection types for each cloud; one for collectd metrics, one for collectd events, one for Ceilometer metrics, and one for Ceilometer events. Configure each of the Smart Gateways to listen on the AMQP address that you define for the corresponding cloud. To define Smart Gateways, configure the `clouds` parameter in the `ServiceTelemetry` manifest.
+endif::include_when_13[]
 
 When you deploy {ProjectShort} for the first time, Smart Gateway manifests are created that define the initial Smart Gateways for a single cloud. When deploying Smart Gateways for multiple cloud support, you deploy multiple Smart Gateways for each of the data collection types that handle the metrics and the events data for each cloud. The initial Smart Gateways are defined under `cloud1` with the following subscription addresses:
 
@@ -32,6 +37,9 @@ When you deploy {ProjectShort} for the first time, Smart Gateway manifests are c
 | **collector** | **type** | **default subscription address**
 | collectd | metrics | collectd/telemetry
 | collectd | events | collectd/notify
+ifdef::include_when_16[]
+| collectd-sensubility | metrics | sensubility/telemetry
+endif::include_when_16[]
 | Ceilometer | metrics | anycast/ceilometer/metering.sample
 | Ceilometer | events | anycast/ceilometer/event.sample
 |===
@@ -84,6 +92,10 @@ spec:
       collectors:
       - collectorType: collectd
         subscriptionAddress: collectd/cloud1-telemetry
+ifdef::include_when_16[]
+      - collectorType: sensubility
+        subscriptionAddress: sensubility/cloud1-telemetry
+endif::include_when_16[]
       - collectorType: ceilometer
         subscriptionAddress: anycast/ceilometer/cloud1-metering.sample
   - name: cloud2
@@ -103,8 +115,11 @@ $ oc get po -l app=smart-gateway
 [source,bash]
 ----
 NAME                                                      READY   STATUS    RESTARTS   AGE
-default-cloud1-ceil-event-smartgateway-6cfb65478c-g5q82   1/1     Running   0          13h
-default-cloud1-ceil-meter-smartgateway-58f885c76d-xmxwn   1/1     Running   0          13h
-default-cloud1-coll-event-smartgateway-58fbbd4485-rl9bd   1/1     Running   0          13h
+default-cloud1-ceil-event-smartgateway-6cfb65478c-g5q82   2/2     Running   0          13h
+default-cloud1-ceil-meter-smartgateway-58f885c76d-xmxwn   2/2     Running   0          13h
+default-cloud1-coll-event-smartgateway-58fbbd4485-rl9bd   2/2     Running   0          13h
 default-cloud1-coll-meter-smartgateway-7c6fc495c4-jn728   2/2     Running   0          13h
+ifdef::include_when_16[]
+default-cloud1-sens-meter-smartgateway-8h4tc445a2-mm683   2/2     Running   0          13h
+endif::include_when_16[]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_monitoring-container-health-and-api-status.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_monitoring-container-health-and-api-status.adoc
@@ -26,9 +26,7 @@
 [role="_abstract"]
 Container health assesses the status of each of the {OpenStack} service containers by periodically running a health check script using the OCI (Open Container Initiative) standard. Most {OpenStack} services implement a health check that logs issues and returns a binary status. For the {OpenStack} APIs, the health checks query the root endpoint and determine the health based on the response time.
 
-To monitor healthchecks in {Project} ({ProjectShort}), you must enable and configure the `collectd-sensubility` plugin to work with the `amqp1` protocol. The {ProjectShort} architecture considers healthcheck results to be events and they are stored in ElasticSearch.
-
-Container health monitoring is enabled by default in `enable-stf.yaml`. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration[].
+To monitor healthchecks in {Project} ({ProjectShort}), you must enable and configure the `collectd-sensubility` plugin to work with the `amqp1` protocol and configure the the amqp1 address. Container health monitoring is enabled by default in `enable-stf.yaml`. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration[].
 
 .Prerequisites
 

--- a/doc-Service-Telemetry-Framework/modules/proc_planning-amqp-address-prefixes.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_planning-amqp-address-prefixes.adoc
@@ -24,7 +24,26 @@
 = Planning AMQP address prefixes
 
 [role="_abstract"]
-By default, {OpenStack} nodes get data through two data collectors; collectd and Ceilometer. These components send telemetry data or notifications to the respective AMQP addresses, for example, `collectd/telemetry`, where {ProjectShort} Smart Gateways listen on those addresses for monitoring data. To support multiple clouds and to identify which cloud generated the monitoring data, configure each cloud to send data to a unique address. Prefix a cloud identifier to the second part of the address. The following list shows some example addresses and identifiers:
+
+ifdef::include_when_16[]
+By default, {OpenStack} nodes receive data through two data collectors; collectd and Ceilometer. The collectd-sensubility plugin requires a unique address. These components send telemetry data or notifications to the respective AMQP addresses, for example, `collectd/telemetry`. {ProjectShort} Smart Gateways listen on those AMQP addresses for monitoring data. To support multiple clouds and to identify which cloud generated the monitoring data, configure each cloud to send data to a unique address. Add a cloud identifier prefix to the second part of the address. The following list shows some example addresses and identifiers:
+
+* `collectd/cloud1-telemetry`
+* `collectd/cloud1-notify`
+* `sensubility/cloud1-telemetry`
+* `anycast/ceilometer/cloud1-metering.sample`
+* `anycast/ceilometer/cloud1-event.sample`
+* `collectd/cloud2-telemetry`
+* `collectd/cloud2-notify`
+* `sensubility/cloud2-telemetry`
+* `anycast/ceilometer/cloud2-metering.sample`
+* `anycast/ceilometer/cloud2-event.sample`
+* `collectd/us-east-1-telemetry`
+* `collectd/us-west-3-telemetry`
+endif::include_when_16[]
+
+ifdef::include_when_13[]
+By default, {OpenStack} nodes receive data through two data collectors; collectd and Ceilometer. These components send telemetry data or notifications to the respective AMQP addresses, for example, collectd/telemetry. {ProjectShort} Smart Gateways listen on the AMQP addresses for monitoring data. To support multiple clouds and to identify which cloud generated the monitoring data, configure each cloud to send data to a unique address. Add a cloud identifier prefix to the second part of the address. The following list shows some example addresses and identifiers:
 
 * `collectd/cloud1-telemetry`
 * `collectd/cloud1-notify`
@@ -36,3 +55,4 @@ By default, {OpenStack} nodes get data through two data collectors; collectd and
 * `anycast/ceilometer/cloud2-event.sample`
 * `collectd/us-east-1-telemetry`
 * `collectd/us-west-3-telemetry`
+endif::include_when_13[]


### PR DESCRIPTION
* adjust sensubility publish address

* Update doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc

Co-authored-by: Leif Madsen <lmadsen@redhat.com>

* Update doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc

Co-authored-by: Leif Madsen <lmadsen@redhat.com>

* updates for new sensubility address

* sensubility clarification

* Update doc-Service-Telemetry-Framework/modules/proc_planning-amqp-address-prefixes.adoc

Co-authored-by: Leif Madsen <lmadsen@redhat.com>

* adjustments

* some items OSP16 only

* All SG output show show 2/2 pods

* Update doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_planning-amqp-address-prefixes.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

* Update doc-Service-Telemetry-Framework/modules/proc_planning-amqp-address-prefixes.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

Co-authored-by: Leif Madsen <lmadsen@redhat.com>
Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>