### PR TITLE
Allow better build controls in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ all: html
 
 html: all-html
 
+downstream: all-html-downstream
+
 pdf: all-pdf
 
 clean: all-clean
@@ -9,7 +11,10 @@ clean: all-clean
 browser: all-browser
 
 all-html:
-	cd doc-Service-Telemetry-Framework && $(MAKE) html
+	cd doc-Service-Telemetry-Framework && $(MAKE) html && $(MAKE) html13
+
+all-html-downstream:
+	cd doc-Service-Telemetry-Framework && $(MAKE) html BUILD=downstream && $(MAKE) html13 BUILD=downstream
 
 all-pdf:
 	cd doc-Service-Telemetry-Framework && $(MAKE) pdf


### PR DESCRIPTION
When building all, build both the html and html13 documents.
Add a new 'downstream' option so you can build for downstream testing as well.
