### PR TITLE
Add back in note about support for OCP nextVersion (#259)

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
@@ -25,17 +25,13 @@ You can use Operators to load the various application components and objects. Ea
 
 .Prerequisites
 
-* {OpenShift} ({OpenShiftShort}) version {SupportedOpenShiftVersion}
-// TODO: add back to previous line when NextSupportedOpenShiftVersion has been tested 
-// or {NextSupportedOpenShiftVersion} is running.
+* {OpenShift} ({OpenShiftShort}) version {SupportedOpenShiftVersion} or {NextSupportedOpenShiftVersion} is running.
 * You have prepared your {OpenShift} ({OpenShiftShort}) environment and ensured that there is persistent storage and enough resources to run the {ProjectShort} components on top of the {OpenShiftShort} environment.
 
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{Project} ({ProjectShort}) is compatible with {OpenShift} version {SupportedOpenShiftVersion}.
-// TODO: add back to previous line when OCP 4.7 has been tested and is supported
-// and {NextSupportedOpenShiftVersion}.
+{Project} ({ProjectShort}) is compatible with {OpenShift} version {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
 endif::[]
 
 .Additional resources

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -23,9 +23,7 @@ ifdef::context[:parent-context: {context}]
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{Project} ({ProjectShort}) is compatible with {OpenShift} versions {SupportedOpenShiftVersion}
-// TODO: add back to previous line when next version is supported
-// and {NextSupportedOpenShiftVersion}.
+{Project} ({ProjectShort}) is compatible with {OpenShift} versions {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
 
 //For more information about migrating, see https://access.redhat.com/articles/5477371[Migrating Service Telemetry Framework v1.0 from OperatorSource to CatalogSource].
 endif::[]

--- a/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
@@ -62,9 +62,7 @@ If you plan to collect and store events, collectd or Ceilometer delivers event d
 Server-side {ProjectShort} monitoring infrastructure consists of the following layers:
 
 * {Project} {ProductVersion} ({ProjectShort})
-* {OpenShift} {SupportedOpenShiftVersion} ({OpenShiftShort}) 
-// TODO: add back to previous line when next version is supported
-// or {NextSupportedOpenShiftVersion}
+* {OpenShift} {SupportedOpenShiftVersion} ({OpenShiftShort}) or {NextSupportedOpenShiftVersion}
 * Infrastructure platform
 
 [[osp-stf-server-side-monitoring]]


### PR DESCRIPTION
Add note about supporting OCP via NextSupportedOpenShiftVersion parameter.

Cherry picked from commit 6ebdbde8c2af85f84d67dd3d456380cdba4d14db
