### PR TITLE
Fix a broken link

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_overview-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_overview-of-the-servicetelemetry-object.adoc
@@ -122,7 +122,7 @@ Use the `alerting` parameter to control creation of an link:https://prometheus.i
 [id="graphing_{context}"]
 == graphing
 
-Use the `graphing` parameter to control the creation of a link:https://grafana.com/docs/grafana/latest/getting-started/what-is-grafana/[Grafana] instance. By default, `graphing` is disabled. For more information, see xref:dashboards_assembly-advanced-features[].
+Use the `graphing` parameter to control the creation of a link:https://grafana.com/docs/grafana/latest/getting-started/#what-is-grafana/[Grafana] instance. By default, `graphing` is disabled. For more information, see xref:dashboards_assembly-advanced-features[].
 
 
 [id="highAvailability_{context}"]


### PR DESCRIPTION
The link led to 404 before. This PR makes it to lead to the grafana docs again.