### PR TITLE
Warn users that they may need to upgrade the Grafana image

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -32,16 +32,20 @@ The Grafana Operator can import and manage dashboards by creating `GrafanaDashbo
 The dashboards require features only available in Grafana versions 8.1.0+.
 
 Check the Grafana version:
-```
++
+[source,bash]
+----
 $ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
 
 docker.io/grafana/grafana:7.3.10
-```
+----
 
 If the running image is old, update it:
-```
++
+[source,bash]
+----
 $ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
-```
+----
 
 This will restart the Grafana deployment.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -29,7 +29,7 @@ The Grafana Operator can import and manage dashboards by creating `GrafanaDashbo
 
 .Prerequisites
 
-The dashboards require features only available in Grafana versions 8.1.0+.
+The dashboards require features only available in Grafana versions 8.1.0 or later.
 
 Check the Grafana version:
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -27,44 +27,6 @@
 [role="_abstract"]
 The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. You can view example dashboards at https://github.com/infrawatch/dashboards.
 
-.Prerequisites
-
-The dashboards require features only available in Grafana versions 8.1.0 or later.
-
-Check the Grafana version:
-+
-[source,bash]
-----
-$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
-
-docker.io/grafana/grafana:7.3.10
-----
-
-If the running image is older than 8.1.0, update it by patching the Grafana object:
-+
-[source,bash]
-----
-$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
-----
-
-It will take a moment to destroy the old Grafana and spin up a new instance.
-
-Verify a new Grafana pod is created and in the running state:
-----
-$ oc get pod -l "app=grafana"
-
-NAME                                 READY     STATUS    RESTARTS   AGE
-grafana-deployment-fb9799b58-j2hj2   1/1       Running   0          10s
-----
-
-Verify that the new instance is running the updated image:
-----
-$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
-
-docker.io/grafana/grafana:8.1.0
-----
-
-
 .Procedure
 
 . Import the infrastructure dashboard:
@@ -118,7 +80,7 @@ rhos-cloud-dashboard   7d21h
 +
 [source,bash,options="nowrap"]
 ----
-$ oc get route grafana-route -ojsonpath='{.spec.host}' 
+$ oc get route grafana-route -ojsonpath='{.spec.host}'
 
 grafana-route-service-telemetry.apps.infra.watch
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -40,7 +40,7 @@ $ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
 docker.io/grafana/grafana:7.3.10
 ----
 
-If the running image is old, update it:
+If the running image is older than 8.1.0, update it by patching the Grafana object:
 +
 [source,bash]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -27,44 +27,6 @@
 [role="_abstract"]
 The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. You can view example dashboards at https://github.com/infrawatch/dashboards.
 
-.Prerequisites
-
-The dashboards require features only available in Grafana versions 8.1.0 or later.
-
-Check the Grafana version:
-+
-[source,bash]
-----
-$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
-
-docker.io/grafana/grafana:7.3.10
-----
-
-If the running image is older than 8.1.0, update it by patching the Grafana object:
-+
-[source,bash]
-----
-$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
-----
-
-It will take a moment to destroy the old Grafana and spin up a new instance.
-
-Verify a new Grafana pod is created and in the running state:
-----
-$ oc get pod -l "app=grafana"
-
-NAME                                 READY     STATUS    RESTARTS   AGE
-grafana-deployment-fb9799b58-j2hj2   1/1       Running   0          10s
-----
-
-Verify that the new instance is running the updated image:
-----
-$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
-
-docker.io/grafana/grafana:8.1.0
-----
-
-
 .Procedure
 
 . Import the infrastructure dashboard:
@@ -93,15 +55,7 @@ grafanadashboard.integreatly.org/rhos-cloudevents-dashboard created
 ----
 +
 [WARNING]
-====
-Some panels in the cloud dashboard require that you set the collectd `virt` plugin parameter `hostname_format` to `name uuid hostname` in the stf-connectors.yaml file. If you do not configure this parameter, affected dashboards remain empty.
-[source,yaml]
-----
-parameter_defaults:
-    ExtraConfig:
-        collectd::plugin::virt::hostname_format: name uuid hostname
-----
-====
+For some panels in the cloud dashboard, you must set the value of the collectd `virt` plugin parameter `hostname_format` to `name uuid hostname` in the `stf-connectors.yaml` file. If you do not configure this parameter, affected dashboards remain empty. For more information about the `virt` plugin, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{vernum}/html-single/service_telemetry_framework_1.2/index#collectd-plugins_assembly[collectd plugins].
 
 . Verify that the dashboards are available:
 +
@@ -118,11 +72,11 @@ rhos-cloud-dashboard   7d21h
 +
 [source,bash,options="nowrap"]
 ----
-$ oc get route grafana-route -ojsonpath='{.spec.host}' 
+$ oc get route grafana-route -ojsonpath='{.spec.host}'
 
 grafana-route-service-telemetry.apps.infra.watch
 ----
 
-. Navigate to https://_<grafana_route_address>_ in a web browser. Replace _<grafana_route_address>_ with the value that you retrieved in the previous step.
+. In a web browser, navigate to https://_<grafana_route_address>_. Replace _<grafana_route_address>_ with the value that you retrieved in the previous step.
 
 . To view the dashboard, click *Dashboards* and *Manage*.

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -27,7 +27,8 @@
 [role="_abstract"]
 The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. You can view example dashboards at https://github.com/infrawatch/dashboards.
 
-<<<<<<<<<<< Warning
+.Prerequisites
+
 The dashboards require features only available in Grafana versions 8.1.0+.
 
 Check the Grafana version:
@@ -43,7 +44,6 @@ $ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/graf
 ```
 
 This will restart the Grafana deployment.
-<<<<<<<<<<< End Warning
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -27,6 +27,24 @@
 [role="_abstract"]
 The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. You can view example dashboards at https://github.com/infrawatch/dashboards.
 
+<<<<<<<<<<< Warning
+The dashboards require features only available in Grafana versions 8.1.0+.
+
+Check the Grafana version:
+```
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
+
+docker.io/grafana/grafana:7.3.10
+```
+
+If the running image is old, update it:
+```
+$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
+```
+
+This will restart the Grafana deployment.
+<<<<<<<<<<< End Warning
+
 .Procedure
 
 . Import the infrastructure dashboard:
@@ -45,7 +63,7 @@ $ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/dep
 
 grafanadashboard.integreatly.org/rhos-cloud-dashboard-1.3 created
 ----
-. Import the cloud events dashboard:
+. Import the cloud events dashboard
 +
 [source,bash,options="nowrap"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -27,6 +27,44 @@
 [role="_abstract"]
 The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. You can view example dashboards at https://github.com/infrawatch/dashboards.
 
+.Prerequisites
+
+The dashboards require features only available in Grafana versions 8.1.0 or later.
+
+Check the Grafana version:
++
+[source,bash]
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
+
+docker.io/grafana/grafana:7.3.10
+----
+
+If the running image is older than 8.1.0, update it by patching the Grafana object:
++
+[source,bash]
+----
+$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
+----
+
+It will take a moment to destroy the old Grafana and spin up a new instance.
+
+Verify a new Grafana pod is created and in the running state:
+----
+$ oc get pod -l "app=grafana"
+
+NAME                                 READY     STATUS    RESTARTS   AGE
+grafana-deployment-fb9799b58-j2hj2   1/1       Running   0          10s
+----
+
+Verify that the new instance is running the updated image:
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
+
+docker.io/grafana/grafana:8.1.0
+----
+
+
 .Procedure
 
 . Import the infrastructure dashboard:
@@ -80,7 +118,7 @@ rhos-cloud-dashboard   7d21h
 +
 [source,bash,options="nowrap"]
 ----
-$ oc get route grafana-route -ojsonpath='{.spec.host}'
+$ oc get route grafana-route -ojsonpath='{.spec.host}' 
 
 grafana-route-service-telemetry.apps.infra.watch
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -63,7 +63,7 @@ $ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/dep
 
 grafanadashboard.integreatly.org/rhos-cloud-dashboard-1.3 created
 ----
-. Import the cloud events dashboard
+. Import the cloud events dashboard:
 +
 [source,bash,options="nowrap"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -47,7 +47,23 @@ If the running image is old, update it:
 $ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
 ----
 
-This will restart the Grafana deployment.
+It will take a moment to destroy the old Grafana and spin up a new instance.
+
+Verify a new Grafana pod is created and in the running state:
+----
+$ oc get pod -l "app=grafana"
+
+NAME                                 READY     STATUS    RESTARTS   AGE
+grafana-deployment-fb9799b58-j2hj2   1/1       Running   0          10s
+----
+
+Verify that the new instance is running the updated image:
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
+
+docker.io/grafana/grafana:8.1.0
+----
+
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -117,20 +117,5 @@ NAME            HOST/PORT                                          PATH   SERVIC
 grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None
 ----
 
-. The dashboards in {ProjectShort} require features that are only available in Grafana version 8.1.0 and later. Ensure that you have the correct version of Grafana:
-+
-[source,bash]
-----
-$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
 
-docker.io/grafana/grafana:7.3.10
-----
 
-. If the running image is older than 8.1.0, update it:
-+
-[source,bash]
-----
-$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
-----
-+
-The Grafana deployment restarts.

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -117,5 +117,20 @@ NAME            HOST/PORT                                          PATH   SERVIC
 grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None
 ----
 
+. The dashboards in {ProjectShort} require features that are only available in Grafana version 8.1.0 and later. Ensure that you have the correct version of Grafana:
++
+[source,bash]
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
 
+docker.io/grafana/grafana:7.3.10
+----
 
+. If the running image is older than 8.1.0, update it:
++
+[source,bash]
+----
+$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
+----
++
+The Grafana deployment restarts.

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -59,7 +59,7 @@ spec:
 EOF
 ----
 
-. To verify that the operator launched successfully, run the `oc get csv` command. If the value of the PHASE column is `Succeeded`, the operator launched successfully:
+. To verify that the operator launched successfully, run the `oc get csv` command. In the command output, if the value of the `PHASE` column is `Succeeded`, the operator launched successfully:
 +
 [source,bash,options="nowrap"]
 ----
@@ -107,7 +107,7 @@ NAME                    AGE
 default-datasources     20h
 ----
 
-. Verify the Grafana route exists:
+. Verify that the Grafana route exists:
 +
 [source,bash,options="nowrap"]
 ----
@@ -117,5 +117,37 @@ NAME            HOST/PORT                                          PATH   SERVIC
 grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None
 ----
 
+. The dashboards in {ProjectShort} require features that are only available in Grafana version 8.1.0 and later. Ensure that you have the correct version of Grafana:
++
+[source,bash]
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
 
+docker.io/grafana/grafana:7.3.10
+----
 
+. If the running image is older than 8.1.0, patch the Grafana object to update the image:
++
+[source,bash,options="nowrap"]
+----
+$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
+----
++
+The Grafana deployment restarts.
+
+. Verify that a new Grafana pod exists and has a `STATUS` value of `Running`:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pod -l "app=grafana"
+NAME                                 READY     STATUS    RESTARTS   AGE
+grafana-deployment-fb9799b58-j2hj2   1/1       Running   0          10s
+----
+
+. Verify that the new instance is running the updated image:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
+docker.io/grafana/grafana:8.1.0
+----


### PR DESCRIPTION
The Grafana operator in Operatorhub that we recommend installing for dashboarding installs an older version of Grafana (v7.3.10) by default. Our newest dashboards utilize features that are only available in Grafana v8.0.0+. At this time, those following the documentation will encounter broken panels and it will appear as if we are releasing dysfunctional dashboards. That's not a good look for us.

Some of the dashboards can be made compatible with v7.3.10, however others require newer features to be useful. Specifically, the cloud-events dashboard needs newer features to be usable. Rather than recommending a Grafana image upgrade for one of the dashboards or waiting for the Operator to be updated, I think it is better to recommend upgrading the image before showing how to deploy the dashboards.

This resolves rhbz#1984079