### PR TITLE
Mas 1999560 table

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -40,7 +40,7 @@ The monitoring data can be either of two types:
 Metric:: a numeric measurement of an application or system
 Event:: irregular and discrete occurrences that happen in a system
 
-The data collection components on the client side are lightweight. The multicast message bus, which is shared by all clients and the deployment, provides fast and reliable data transport. Other modular components that receive and store data are deployed in containers on {OpenShift}.
+The multicast message bus provides fast, reliable data transport and is shared by all the clients in the deployment. Other modular components that receive and store data are deployed in containers on {OpenShift}.
 
 ifeval::["{build}" == "downstream"]
 include::../modules/con_support-for-stf.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -23,20 +23,18 @@ ifdef::context[:parent-context: {context}]
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{Project} ({ProjectShort}) is compatible with {OpenShift} versions {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
+{Project} ({ProjectShort}) is compatible with {OpenShift}  versions {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
 
 //For more information about migrating, see https://access.redhat.com/articles/5477371[Migrating Service Telemetry Framework v1.0 from OperatorSource to CatalogSource].
 endif::[]
 
 [role="_abstract"]
-{Project} ({ProjectShort}) receives monitoring data from {OpenStack} or third-party nodes for storage, viewing on dashboards, and alerting. The monitoring data can be either of two types:
+{Project} ({ProjectShort}) receives monitoring data from {OpenStack} or third-party nodes. You can use {ProjectShort} {ProjectShort} to monitor functions such as alert generation, visualization through dashboards, and single source of truth telemetry analysis to support orchestration.The monitoring data can be either of two types:
 
 Metric:: a numeric measurement of an application or system
 Event:: irregular and discrete occurrences that happen in a system
 
-The collection components that are required on the clients are lightweight. The multicast message bus that is shared by all clients and the deployment provides fast and reliable data transport. Other modular components for receiving and storing data are deployed in containers on {OpenShiftShort}.
-
-{ProjectShort} provides access to monitoring functions such as alert generation, visualization through dashboards, and single source of truth telemetry analysis to support orchestration.
+The data collection components on the client side are lightweight. The multicast message bus, which is shared by all clients and the deployment, provides fast and reliable data transport. Other modular components that receive and store data are deployed in containers on {OpenShiftShort}.
 
 ifeval::["{build}" == "downstream"]
 include::../modules/con_support-for-stf.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -23,7 +23,7 @@ ifdef::context[:parent-context: {context}]
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{Project} ({ProjectShort}) is compatible with {OpenShift}  versions {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
+{Project} ({ProjectShort}) is compatible with {OpenShift} versions {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
 
 //For more information about migrating, see https://access.redhat.com/articles/5477371[Migrating Service Telemetry Framework v1.0 from OperatorSource to CatalogSource].
 endif::[]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -29,7 +29,13 @@ ifeval::["{build}" == "downstream"]
 endif::[]
 
 [role="_abstract"]
-{Project} ({ProjectShort}) receives monitoring data from {OpenStack} or third-party nodes. You can use {ProjectShort} to monitor functions such as alert generation, visualization through dashboards, and single source of truth telemetry analysis to support orchestration. The monitoring data can be either of two types:
+{Project} ({ProjectShort}) collects monitoring data from {OpenStack} or third party nodes. With {ProjectShort}, you can perform the following tasks:
+
+* Store or archive the monitoring data for historical information
+* View the monitoring data graphically on the dashboard
+* Use the monitoring data to trigger alerts or warnings
+
+The monitoring data can be either of two types:
 
 Metric:: a numeric measurement of an application or system
 Event:: irregular and discrete occurrences that happen in a system

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -29,12 +29,12 @@ ifeval::["{build}" == "downstream"]
 endif::[]
 
 [role="_abstract"]
-{Project} ({ProjectShort}) receives monitoring data from {OpenStack} or third-party nodes. You can use {ProjectShort} {ProjectShort} to monitor functions such as alert generation, visualization through dashboards, and single source of truth telemetry analysis to support orchestration.The monitoring data can be either of two types:
+{Project} ({ProjectShort}) receives monitoring data from {OpenStack} or third-party nodes. You can use {ProjectShort} to monitor functions such as alert generation, visualization through dashboards, and single source of truth telemetry analysis to support orchestration. The monitoring data can be either of two types:
 
 Metric:: a numeric measurement of an application or system
 Event:: irregular and discrete occurrences that happen in a system
 
-The data collection components on the client side are lightweight. The multicast message bus, which is shared by all clients and the deployment, provides fast and reliable data transport. Other modular components that receive and store data are deployed in containers on {OpenShiftShort}.
+The data collection components on the client side are lightweight. The multicast message bus, which is shared by all clients and the deployment, provides fast and reliable data transport. Other modular components that receive and store data are deployed in containers on {OpenShift}.
 
 ifeval::["{build}" == "downstream"]
 include::../modules/con_support-for-stf.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
@@ -13,9 +13,9 @@
 
 [[table-stf-components]]
 .{ProjectShort} components
-[cols="15,70,15"]
+[cols="65,15,20"]
 |===
-|Component |Client  |Server ({OpenShiftShort})
+|Component |Client  |Server ({OpenShift})
 
 |An AMQP 1.x compatible messaging bus to shuttle the metrics to {ProjectShort} for storage in Prometheus
 |yes
@@ -61,7 +61,7 @@ If you plan to collect and store events, collectd or Ceilometer delivers event d
 Server-side {ProjectShort} monitoring infrastructure consists of the following layers:
 
 * {Project} {ProductVersion} ({ProjectShort})
-* {OpenShift} {SupportedOpenShiftVersion} ({OpenShiftShort}) or {NextSupportedOpenShiftVersion}
+* {OpenShift} {SupportedOpenShiftVersion} or {NextSupportedOpenShiftVersion}
 * Infrastructure platform
 
 [[osp-stf-server-side-monitoring]]
@@ -70,9 +70,9 @@ image::STF_Overview_37_0819_deployment_prereq.png[Server-side STF monitoring inf
 
 
 [NOTE]
-Do not install {OpenShiftShort} on the same infrastructure that you want to monitor.
+Do not install {OpenShift} on the same infrastructure that you want to monitor.
 
 .Additional resources
 
-* For more information about how to deploy {OpenShift}, see the  https://access.redhat.com/documentation/en-us/openshift_container_platform/{SupportedOpenShiftVersion}/[{OpenShiftShort} product documentation].
-* You can install {OpenShiftShort} on cloud platforms or on bare metal. For more information about {ProjectShort} performance and scaling, see https://access.redhat.com/articles/4907241.
+* For more information about how to deploy {OpenShift}, see the  https://access.redhat.com/documentation/en-us/openshift_container_platform/{SupportedOpenShiftVersion}/[{OpenShift} product documentation].
+* You can install {OpenShift} on cloud platforms or on bare metal. For more information about {ProjectShort} performance and scaling, see https://access.redhat.com/articles/4907241.

--- a/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
@@ -15,34 +15,33 @@
 .{ProjectShort} components
 [cols="15,70,15"]
 |===
-|Client |Component |Server ({OpenShiftShort})
+|Component |Client  |Server ({OpenShiftShort})
 
-|yes
 |An AMQP 1.x compatible messaging bus to shuttle the metrics to {ProjectShort} for storage in Prometheus
 |yes
+|yes
 
-|no
 |Smart Gateway to pick metrics and events from the AMQP 1.x bus and to deliver events to ElasticSearch or to provide metrics to Prometheus
+|no
 |yes
 
-|no
 |Prometheus as time-series data storage
+|no
 |yes
 
-|no
 |ElasticSearch as events data storage
+|no
 |yes
 
-|yes
 |collectd to collect infrastructure metrics and events
+|yes
 |no
 
-|yes
 |Ceilometer to collect {OpenStack} metrics and events
+|yes
 |no
 
 |===
-
 
 [[osp-stf-overview]]
 .Service Telemetry Framework architecture overview
@@ -55,7 +54,7 @@ The {Project} data collection components, collectd and Ceilometer, and the trans
 
 endif::[]
 
-For metrics, on the client side, collectd provides infrastructure metrics (without project data), and Ceilometer provides {OpenStack} platform data based on projects or user workload. Both Ceilometer and collectd deliver data to Prometheus by using the {MessageBus} transport, delivering the data through the message bus. On the server side, a Golang application called the Smart Gateway takes the data stream from the bus and exposes it as a local scrape endpoint for Prometheus.
+For metrics, on the client side, collectd provides infrastructure metrics without project data, and Ceilometer provides {OpenStack} platform data based on projects or user workload. Both Ceilometer and collectd deliver data to Prometheus by using the {MessageBus} transport, delivering the data through the message bus. On the server side, a Golang application called the Smart Gateway takes the data stream from the bus and exposes it as a local scrape endpoint for Prometheus.
 
 If you plan to collect and store events, collectd or Ceilometer delivers event data to the server side by using the {MessageBus} transport, delivering the data through the message bus. Another Smart Gateway writes the data to the ElasticSearch datastore.
 
@@ -76,5 +75,4 @@ Do not install {OpenShiftShort} on the same infrastructure that you want to moni
 .Additional resources
 
 * For more information about how to deploy {OpenShift}, see the  https://access.redhat.com/documentation/en-us/openshift_container_platform/{SupportedOpenShiftVersion}/[{OpenShiftShort} product documentation].
-* You can install {OpenShiftShort} on cloud platforms or on bare metal.
-For more information about {ProjectShort} performance and scaling, see https://access.redhat.com/articles/4907241.
+* You can install {OpenShiftShort} on cloud platforms or on bare metal. For more information about {ProjectShort} performance and scaling, see https://access.redhat.com/articles/4907241.


### PR DESCRIPTION
Changed layout of the table to make it more accessible.
Removed all reference to OCP out of intro and architecture section. OpenShift team does not use this acronym. 
Minor text edits to intro. 