### PR TITLE
We should never set presettle to true

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -98,7 +98,7 @@ endif::include_when_13[]
             presettle: false
         cloud1-telemetry:     # <6>
             format: JSON
-            presettle: true
+            presettle: false
 
 ifdef::include_when_16[]
     CollectdSensubilityResultsChannel: sensubility/cloud1-telemetry # <7>


### PR DESCRIPTION
Delivery of messages should never be done via presettle as that can
cause issues with lost messages.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
