### PR TITLE
We should never set presettle to true

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file.adoc
@@ -167,7 +167,7 @@ parameter_defaults:
             presettle: false
         cloud1-telemetry:     # <4>
             format: JSON
-            presettle: true
+            presettle: false
     CollectdEnableSensubility: true # <6>
     CollectdSensubilityTransport: amqp1
     CollectdSensubilityResultsChannel: collectd/cloud1-notify # <7>


### PR DESCRIPTION
Delivery of messages should never be done via presettle as that can cause issues with lost messages.
