### PR TITLE
stf13/cp 0bd554464070a6d2408c07309c97379942e33db8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ all: html
 
 html: all-html
 
+downstream: all-html-downstream
+
 pdf: all-pdf
 
 clean: all-clean
@@ -9,7 +11,10 @@ clean: all-clean
 browser: all-browser
 
 all-html:
-	cd doc-Service-Telemetry-Framework && $(MAKE) html
+	cd doc-Service-Telemetry-Framework && $(MAKE) html && $(MAKE) html13
+
+all-html-downstream:
+	cd doc-Service-Telemetry-Framework && $(MAKE) html BUILD=downstream && $(MAKE) html13 BUILD=downstream
 
 all-pdf:
 	cd doc-Service-Telemetry-Framework && $(MAKE) pdf

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
@@ -1,16 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// <List assemblies here, each on a new line>
-
-////
-Retains the context of the parent assembly if this assembly is nested within another assembly.
-For more information about nesting assemblies, see: https://redhat-documentation.github.io/modular-docs/#nesting-assemblies
-See also the complementary step on the last line of this file.
-////
-
-ifdef::context[:parent-context: {context}]
-
-
 [id="assembly-advanced-features_{context}"]
 = Advanced features
 
@@ -28,7 +15,9 @@ The following optional features can provide additional functionality to the {Pro
 * xref:high-availability_assembly-advanced-features[]
 * xref:dashboards_assembly-advanced-features[]
 * xref:ephemeral-storage_assembly-advanced-features[]
+ifdef::include_when_16[]
 * xref:monitoring-resource-usage-of-openstack-services_assembly-advanced-features[]
+endif::include_when_16[]
 * xref:creating-a-route-in-ocp_assembly-advanced-features[]
 
 // Customizing the deployment (manifest overrides)

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
@@ -32,6 +32,10 @@ As part of an {OpenStack} overcloud deployment, you might need to configure addi
 
 * To send metrics to both Gnocchi and {ProjectShort}, see xref:sending-metrics-to-gnocchi-and-to-stf_assembly-completing-the-stf-configuration[].
 
+ifdef::include_when_13[]
+* If you synchronized container images to a local registry, you must create an environment file and include the paths to the container images. For more information, see xref:adding-container-images-to-the-undercloud_assembly-completing-the-stf-configuration[].
+endif::include_when_13[]
+
 // Basic overcloud deployment using default parameters
 include::../modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc[leveloffset=+1]
 ifdef::include_when_13[]
@@ -48,6 +52,11 @@ include::../modules/proc_sending-metrics-to-gnocchi-and-to-stf.adoc[leveloffset=
 
 // Gather information for deployment in non-standard network topologies in the OSP overcloud
 include::../modules/proc_deploying-to-non-standard-network-topologies.adoc[leveloffset=+1]
+
+ifdef::include_when_13[]
+// If you synchronized container images to a local registry, create an environment file and include the paths to the container images
+include::../modules/proc_adding-container-images-to-the-undercloud.adoc[leveloffset=+1]
+endif::include_when_13[]
 
 //Connecting multiple clouds
 include::../modules/con_configuring-multiple-clouds.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
@@ -30,7 +30,9 @@ As part of an {OpenStack} overcloud deployment, you might need to configure addi
 
 * To deploy data collection and transport to {ProjectShort} on {OpenStack} cloud nodes that employ routed L3 domains, such as distributed compute node (DCN) or spine-leaf, see xref:deploying-to-non-standard-network-topologies_assembly-completing-the-stf-configuration[].
 
+ifdef::include_when_16[]
 * To send metrics to both Gnocchi and {ProjectShort}, see xref:sending-metrics-to-gnocchi-and-to-stf_assembly-completing-the-stf-configuration[].
+endif::include_when_16[]
 
 ifdef::include_when_13[]
 * If you synchronized container images to a local registry, you must create an environment file and include the paths to the container images. For more information, see xref:adding-container-images-to-the-undercloud_assembly-completing-the-stf-configuration[].
@@ -48,7 +50,9 @@ include::../modules/proc_deploying-the-overcloud.adoc[leveloffset=+2]
 include::../modules/proc_validating-clientside-installation.adoc[leveloffset=+2]
 
 //Sending metrics to Gnocchi and to STF
+ifdef::include_when_16[]
 include::../modules/proc_sending-metrics-to-gnocchi-and-to-stf.adoc[leveloffset=+1]
+endif::include_when_16[]
 
 // Gather information for deployment in non-standard network topologies in the OSP overcloud
 include::../modules/proc_deploying-to-non-standard-network-topologies.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
@@ -57,8 +57,9 @@ include::../modules/proc_subscribing-to-the-elastic-cloud-on-kubernetes-operator
 include::../modules/proc_subscribing-to-the-service-telemetry-operator.adoc[leveloffset=+2]
 
 
-include::../modules/con_overview-of-the-servicetelemetry-object.adoc[leveloffset=+1]
+
 include::../modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc[leveloffset=+1]
+include::../modules/con_primary-parameters-of-the-servicetelemetry-object.adoc[leveloffset=+2]
 include::../modules/proc_removing-stf-from-the-openshift-environment.adoc[leveloffset=+1]
 
 

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
@@ -25,17 +25,13 @@ You can use Operators to load the various application components and objects. Ea
 
 .Prerequisites
 
-* {OpenShift} ({OpenShiftShort}) version {SupportedOpenShiftVersion}
-// TODO: add back to previous line when NextSupportedOpenShiftVersion has been tested 
-// or {NextSupportedOpenShiftVersion} is running.
+* {OpenShift} ({OpenShiftShort}) version {SupportedOpenShiftVersion} or {NextSupportedOpenShiftVersion} is running.
 * You have prepared your {OpenShift} ({OpenShiftShort}) environment and ensured that there is persistent storage and enough resources to run the {ProjectShort} components on top of the {OpenShiftShort} environment.
 
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{Project} ({ProjectShort}) is compatible with {OpenShift} version {SupportedOpenShiftVersion}.
-// TODO: add back to previous line when OCP 4.7 has been tested and is supported
-// and {NextSupportedOpenShiftVersion}.
+{Project} ({ProjectShort}) is compatible with {OpenShift} version {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
 endif::[]
 
 .Additional resources

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -23,9 +23,7 @@ ifdef::context[:parent-context: {context}]
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{Project} ({ProjectShort}) is compatible with {OpenShift} versions {SupportedOpenShiftVersion}
-// TODO: add back to previous line when next version is supported
-// and {NextSupportedOpenShiftVersion}.
+{Project} ({ProjectShort}) is compatible with {OpenShift} versions {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
 
 //For more information about migrating, see https://access.redhat.com/articles/5477371[Migrating Service Telemetry Framework v1.0 from OperatorSource to CatalogSource].
 endif::[]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -29,14 +29,18 @@ ifeval::["{build}" == "downstream"]
 endif::[]
 
 [role="_abstract"]
-{Project} ({ProjectShort}) receives monitoring data from {OpenStack} or third-party nodes for storage, viewing on dashboards, and alerting. The monitoring data can be either of two types:
+{Project} ({ProjectShort}) collects monitoring data from {OpenStack} or third party nodes. With {ProjectShort}, you can perform the following tasks:
+
+* Store or archive the monitoring data for historical information
+* View the monitoring data graphically on the dashboard
+* Use the monitoring data to trigger alerts or warnings
+
+The monitoring data can be either of two types:
 
 Metric:: a numeric measurement of an application or system
 Event:: irregular and discrete occurrences that happen in a system
 
-The collection components that are required on the clients are lightweight. The multicast message bus that is shared by all clients and the deployment provides fast and reliable data transport. Other modular components for receiving and storing data are deployed in containers on {OpenShiftShort}.
-
-{ProjectShort} provides access to monitoring functions such as alert generation, visualization through dashboards, and single source of truth telemetry analysis to support orchestration.
+The multicast message bus provides fast, reliable data transport and is shared by all the clients in the deployment. Other modular components that receive and store data are deployed in containers on {OpenShift}.
 
 ifeval::["{build}" == "downstream"]
 include::../modules/con_support-for-stf.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_preparing-your-ocp-environment-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_preparing-your-ocp-environment-for-stf.adoc
@@ -19,19 +19,23 @@ ifdef::context[:parent-context: {context}]
 :context: assembly-preparing-your-ocp-environment-for-stf
 
 [role="_abstract"]
-As you prepare your {OpenShiftShort} environment for {ProjectShort}, you must plan for persistent storage, adequate resources, and event storage:
+As you prepare your {OpenShift} environment for {Project} ({ProjectShort}), you must plan for persistent storage, adequate resources, and event storage:
 
 * Ensure that persistent storage is available in your {OpenShift} cluster to permit a production grade deployment. For more information, see <<persistent-volumes_assembly-preparing-your-ocp-environment-for-stf>>.
 * Ensure that enough resources are available to run the Operators and the application containers. For more information, see <<resource-allocation_assembly-preparing-your-ocp-environment-for-stf>>.
 * To install ElasticSearch, you must use a community catalog source. If you do not want to use a community catalog or if you do not want to store events, see <<deploying-stf-to-the-openshift-environment_assembly-installing-the-core-components-of-stf>>.
+
+ifeval::["{build}" == "upstream"]
 * {ProjectShort} uses ElasticSearch to store events, which requires a larger than normal `vm.max_map_count`. The `vm.max_map_count` value is set by default in {OpenShift}. For more information about how to edit the value of `vm.max_map_count`, see <<node-tuning-operator_assembly-preparing-your-ocp-environment-for-stf>>.
+endif::[]
 
 include::../modules/con_persistent-volumes.adoc[leveloffset=+1]
 include::../modules/con_ephemeral-storage.adoc[leveloffset=+2]
 include::../modules/con_resource-allocation.adoc[leveloffset=+1]
 include::../modules/con_metrics-retention-time-period.adoc[leveloffset=+1]
+ifeval::["{build}" == "upstream"]
 include::../modules/con_node-tuning-operator.adoc[leveloffset=+1]
-
+endif::[]
 
 //reset the context
 ifdef::parent-context[:context: {parent-context}]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc
@@ -41,7 +41,7 @@ When the new Operators start, they reconcile the existing `ServiceTelemetry` and
 
 * To check the state of the Smart Gateway containers, use the `oc get pods` command:
 +
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
 oc get pods
 

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc
@@ -1,0 +1,59 @@
+// This assembly is included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+////
+Retains the context of the parent assembly if this assembly is nested within another assembly.
+For more information about nesting assemblies, see: https://redhat-documentation.github.io/modular-docs/#nesting-assemblies
+See also the complementary step on the last line of this file.
+////
+
+ifdef::context[:parent-context: {context}]
+
+[id="assembly-upgrading-service-telemetry-framework-to-version-1-3_{context}"]
+= Upgrading Service Telemetry Framework to version 1.3
+
+// The `context` attribute enables module reuse. Every module's ID
+// includes {context}, which ensures that the module has a unique ID even if
+// it is reused multiple times in a guide.
+:context: assembly-upgrading-service-telemetry-framework-to-version-1-3
+
+[role="_abstract"]
+To migrate from {Project} ({ProjectShort}) v1.2 to {ProjectShort} v1.3, you must replace the `ClusterServiceVersion` and `Subscription` objects in the `service-telemetry` namespace on your {OpenShift} ({OpenShiftShort}) environment.
+
+.Prerequisites
+
+* You have upgraded your {OpenShiftShort} environment to v4.6. {ProjectShort} v1.3 does not run on {OpenShiftShort} v4.5 and lower.{ProjectShort} v1.2 does not run on {OpenShiftShort} v4.7 and higher.
+* You have backed up your data prior to any upgrade of the environment. Upgrading {ProjectShort} v1.2 to v1.3 results in a brief outage while the Smart Gateways are upgraded. Additionally, changes to the `ServiceTelemetry` and `SmartGateway` objects do not have any effect while the Operators are being replaced.
+
+To upgrade from {ProjectShort} v1.2 to v1.3, complete the following procedures:
+
+.Procedure
+
+. xref:removing-service-telemetry-framework-1-2-operators_assembly-upgrading-service-telemetry-framework-to-version-1-3[Remove the {ProjectShort} 1.2 Operators].
+. xref:subscribing-to-the-service-telemetry-operator_assembly-upgrading-service-telemetry-framework-to-version-1-3[Subscribe to the Service Telemetry Operator].
+
+
+include::../modules/proc_removing-service-telemetry-framework-1-2-operators.adoc[leveloffset=+1]
+include::../modules/proc_subscribing-to-the-service-telemetry-operator.adoc[leveloffset=+1]
+
+When the new Operators start, they reconcile the existing `ServiceTelemetry` and `SmartGateway` objects, resulting in the restart of Smart Gateway containers.
+
+* To check the state of the Smart Gateway containers, use the `oc get pods` command:
++
+[source,bash,options="nowrap",subs="+quotes"]
+----
+oc get pods
+
+NAME                                                      READY   STATUS        RESTARTS   AGE
+...
+default-cloud1-ceil-meter-smartgateway-5849c4cdb5-xgl42   1/1     Running       0          35s
+default-cloud1-coll-meter-smartgateway-749674f75c-k7pm7   2/2     Terminating   0          56m
+default-cloud1-coll-meter-smartgateway-868476456b-ksh9b   2/2     Running       0          26s
+...
+----
+
+// The following line is necessary to allow assemblies be included in other
+// assemblies. It restores the `context` variable to its previous state.
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/doc-Service-Telemetry-Framework/docinfo.xml
+++ b/doc-Service-Telemetry-Framework/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Service Telemetry Framework 1.3</title>
 <subtitle>Installing and deploying Service Telemetry Framework 1.3</subtitle>
 <productname>Red Hat OpenStack Platform</productname>
-<productnumber>16.1</productnumber>
+<productnumber>13</productnumber>
 <pubsnumber>0</pubsnumber>
 <abstract>
   <para>

--- a/doc-Service-Telemetry-Framework/docinfo.xml
+++ b/doc-Service-Telemetry-Framework/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Service Telemetry Framework 1.3</title>
 <subtitle>Installing and deploying Service Telemetry Framework 1.3</subtitle>
 <productname>Red Hat OpenStack Platform</productname>
-<productnumber>13</productnumber>
+<productnumber>16.1</productnumber>
 <pubsnumber>0</pubsnumber>
 <abstract>
   <para>

--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -28,5 +28,8 @@ include::assemblies/assembly_completing-the-stf-configuration.adoc[leveloffset=+
 //advanced features
 include::assemblies/assembly_advanced-features.adoc[leveloffset=+1]
 
+// upgrading to 1.3
+include::assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc[leveloffset=+1]
+
 //collectd plugins
 include::common/collectd/ref_collectd-plugins.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -1,7 +1,7 @@
 = Service Telemetry Framework 1.3
 OpenStack Documentation Team <rhos-docs@redhat.com>
 :imagesdir: images
-:vernum: 13
+:vernum: 16.1
 :toc: left
 :toclevels: 3
 :icons: font

--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -1,7 +1,7 @@
 = Service Telemetry Framework 1.3
 OpenStack Documentation Team <rhos-docs@redhat.com>
 :imagesdir: images
-:vernum: 16.1
+:vernum: 13
 :toc: left
 :toclevels: 3
 :icons: font

--- a/doc-Service-Telemetry-Framework/modules/con_metrics-retention-time-period.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_metrics-retention-time-period.adoc
@@ -28,8 +28,9 @@
 [role="_abstract"]
 The default retention time for metrics stored in {ProjectShort} is 24 hours, which provides enough data to allow for trends to develop for the purposes of alerting. To adjust {ProjectShort} for additional metrics retention time, set a new value in `backends.metrics.prometheus.storage.retention`, for example, `7d` for seven days. If you use long retention periods, returning data from heavily populated Prometheus systems can result in queries returning slowly.
 
-For long-term storage, use systems designed for long-term data retention, for example, https://thanos.io/[Thanos].
+For long-term storage, use systems designed for long-term data retention, for example, Thanos.
 
 .Additional resources
 
 * For recommendations about Prometheus data storage and estimating storage space, see https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects
+* For more information about Thanos, see https://thanos.io/

--- a/doc-Service-Telemetry-Framework/modules/con_overview-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_overview-of-the-servicetelemetry-object.adoc
@@ -139,7 +139,7 @@ Use the `alerting` parameter to control creation of an link:https://prometheus.i
 [id="graphing_{context}"]
 == graphing
 
-Use the `graphing` parameter to control the creation of a link:https://grafana.com/docs/grafana/latest/getting-started/what-is-grafana/[Grafana] instance. By default, `graphing` is disabled. For more information, see xref:dashboards_assembly-advanced-features[].
+Use the `graphing` parameter to control the creation of a link:https://grafana.com/docs/grafana/latest/getting-started/#what-is-grafana/[Grafana] instance. By default, `graphing` is disabled. For more information, see xref:dashboards_assembly-advanced-features[].
 
 [id="highAvailability_{context}"]
 == highAvailability

--- a/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
@@ -3,7 +3,7 @@
 // <List assemblies here, each on a new line>
 
 // This module can be included from assemblies using the following include statement:
-// include::<path>/con_overview-of-the-servicetelemetry-object.adoc[leveloffset=+1]
+// include::<path>/con_primary-parameters-of-the-servicetelemetry-object.adoc[leveloffset=+1]
 
 // The file name and the ID are based on the module title. For example:
 // * file name: con_my-concept-module-a.adoc
@@ -22,11 +22,11 @@
 // readers and search engines find information quickly.
 // Do not start the title with a verb. See also _Wording of headings_
 // in _The IBM Style Guide_.
-[id="overview-of-the-servicetelemetry-object"]
-= Overview of the ServiceTelemetry object
+[id="primary-parameters-of-the-servicetelemetry-object"]
+= Primary parameters of the ServiceTelemetry object
 
 [role="_abstract"]
-To deploy the {Project}, you must create an instance of `ServiceTelemetry` in {OpenShiftShort}. The `ServiceTelemetry` object is made up of the following major configuration parameters:
+To deploy {ProjectShort}, you must create an instance of `ServiceTelemetry` in {OpenShift}. The `ServiceTelemetry` object is made up of the following major configuration parameters:
 
 * `alerting`
 * `backends`
@@ -35,7 +35,7 @@ To deploy the {Project}, you must create an instance of `ServiceTelemetry` in {O
 * `highAvailability`
 * `transports`
 
-Each of these top-level configuration parameters provides various controls for a {Project} deployment.
+Each of these top-level configuration parameters provides various controls for a {ProjectShort} deployment.
 
 [IMPORTANT]
 ====
@@ -47,7 +47,7 @@ Support for `servicetelemetry.infra.watch/v1alpha1` was removed from {ProjectSho
 
 Use the `backends` parameter to control which storage backends are available for storage of metrics and events, and to control the enablement of Smart Gateways, as defined by the `clouds` parameter. For more information, see xref:clouds_assembly-installing-the-core-components-of-stf[].
 
-Currently, you can use Prometheus as the metrics backend, and ElasticSearch as the events backend.
+Currently, you can use Prometheus as the metrics backend and ElasticSearch as the events backend.
 
 
 === Enabling Prometheus as a storage backend for metrics
@@ -99,7 +99,7 @@ spec:
 
 Use the `clouds` parameter to control which Smart Gateway objects are deployed, thereby providing the interface for multiple monitored cloud environments to connect to an instance of {ProjectShort}. If a supporting backend is available, then metrics and events Smart Gateways for the default cloud configuration are created. By default, the Service Telemetry Operator creates Smart Gateways for `cloud1`.
 
-You can create a list of cloud objects to control which Smart Gateways are created for each cloud defined. Each cloud is made up of data types and collectors. Data types are `metrics` or `events`. Each data type is made up of a list of collectors and the message bus subscription address. Available collectors are `collectd` and `ceilometer`. Ensure that the subscription address for each of these collectors is unique for every cloud, data type, and collector combination.
+You can create a list of cloud objects to control which Smart Gateways are created for the defined clouds. Each cloud consists of data types and collectors. Data types are `metrics` or `events`. Each data type is made up of a list of collectors and the message bus subscription address. Available collectors are `collectd` and `ceilometer`. Ensure that the subscription address for each of these collectors is unique for every cloud, data type, and collector combination.
 
 The default `cloud1` configuration is represented by the following `ServiceTelemetry` object, providing subscriptions and data storage of metrics and events for both collectd and Ceilometer data collectors for a particular cloud instance:
 
@@ -127,26 +127,26 @@ spec:
             subscriptionAddress: anycast/ceilometer/event.sample
 ----
 
-Each item of the `clouds` parameter represents a cloud instance. The cloud instances are made up of 3 top-level parameters: `name`, `metrics`, and `events`. The `metrics` and `events` parameters represent the corresponding backend for storage of that data type. The `collectors` parameter specifies a list of objects made up of two required parameters, `collectorType` and `subscriptionAddress`, and these represent an instance of the Smart Gateway. The `collectorType` parameter specifies data collected by either collectd or Ceilometer. The `subscriptionAddress` parameter provides the {MessageBus} address to which a Smart Gateway should subscribe.
+Each item of the `clouds` parameter represents a cloud instance. The cloud instances are made up of three top-level parameters: `name`, `metrics`, and `events`. The `metrics` and `events` parameters represent the corresponding backend for storage of that data type. The `collectors` parameter specifies a list of objects made up of two required parameters, `collectorType` and `subscriptionAddress`, and these represent an instance of the Smart Gateway. The `collectorType` parameter specifies data collected by either collectd or Ceilometer. The `subscriptionAddress` parameter provides the {MessageBus} address to which a Smart Gateway should subscribe.
 
 You can use the optional Boolean parameter `debugEnabled` within the `collectors` parameter to enable additional console debugging in the running Smart Gateway pod.
 
 [id="alerting_{context}"]
 == alerting
 
-Use the `alerting` parameter to control creation of an link:https://prometheus.io/docs/alerting/latest/alertmanager/[Alertmanager] instance and the configuration of the storage backend. By default, `alerting` is enabled. For more information, see xref:alerts_assembly-advanced-features[].
+Use the `alerting` parameter to control creation of an Alertmanager instance and the configuration of the storage backend. By default, `alerting` is enabled. For more information, see xref:alerts_assembly-advanced-features[].
 
 [id="graphing_{context}"]
 == graphing
 
-Use the `graphing` parameter to control the creation of a link:https://grafana.com/docs/grafana/latest/getting-started/#what-is-grafana/[Grafana] instance. By default, `graphing` is disabled. For more information, see xref:dashboards_assembly-advanced-features[].
+Use the `graphing` parameter to control the creation of a Grafana instance. By default, `graphing` is disabled. For more information, see xref:dashboards_assembly-advanced-features[].
 
 [id="highAvailability_{context}"]
 == highAvailability
 
-Use The `highAvailability` parameter to control the instantiation of multiple copies of {ProjectShort} components to reduce recovery time of components that fail or are rescheduled. By default, `highAvailability` is disabled. For more information, see xref:high-availability_assembly-advanced-features[].
+Use the `highAvailability` parameter to control the instantiation of multiple copies of {ProjectShort} components to reduce recovery time of components that fail or are rescheduled. By default, `highAvailability` is disabled. For more information, see xref:high-availability_assembly-advanced-features[].
 
 [id="transports_{context}"]
 == transports
 
-Use the `transports` parameter to control the enablement of the message bus for a {ProjectShort} deployment. The only transport currently supported is {MessageBus}. Ensure that it is enabled for proper operation of {ProjectShort}. By default, the `qdr` transport is enabled.
+Use the `transports` parameter to control the enablement of the message bus for a {ProjectShort} deployment. The only transport currently supported is {MessageBus}. Ensure that {MessageBus} is enabled for correct operation of {ProjectShort}. By default, the `qdr` transport is enabled.

--- a/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
@@ -13,36 +13,35 @@
 
 [[table-stf-components]]
 .{ProjectShort} components
-[cols="15,70,15"]
+[cols="65,15,20"]
 |===
-|Client |Component |Server ({OpenShiftShort})
+|Component |Client  |Server ({OpenShift})
 
-|yes
 |An AMQP 1.x compatible messaging bus to shuttle the metrics to {ProjectShort} for storage in Prometheus
 |yes
+|yes
 
-|no
 |Smart Gateway to pick metrics and events from the AMQP 1.x bus and to deliver events to ElasticSearch or to provide metrics to Prometheus
+|no
 |yes
 
-|no
 |Prometheus as time-series data storage
+|no
 |yes
 
-|no
 |ElasticSearch as events data storage
+|no
 |yes
 
-|yes
 |collectd to collect infrastructure metrics and events
+|yes
 |no
 
-|yes
 |Ceilometer to collect {OpenStack} metrics and events
+|yes
 |no
 
 |===
-
 
 [[osp-stf-overview]]
 .Service Telemetry Framework architecture overview
@@ -55,14 +54,14 @@ The {Project} data collection components, collectd and Ceilometer, and the trans
 
 endif::[]
 
-For metrics, on the client side, collectd provides infrastructure metrics (without project data), and Ceilometer provides {OpenStack} platform data based on projects or user workload. Both Ceilometer and collectd deliver data to Prometheus by using the {MessageBus} transport, delivering the data through the message bus. On the server side, a Golang application called the Smart Gateway takes the data stream from the bus and exposes it as a local scrape endpoint for Prometheus.
+For metrics, on the client side, collectd provides infrastructure metrics without project data, and Ceilometer provides {OpenStack} platform data based on projects or user workload. Both Ceilometer and collectd deliver data to Prometheus by using the {MessageBus} transport, delivering the data through the message bus. On the server side, a Golang application called the Smart Gateway takes the data stream from the bus and exposes it as a local scrape endpoint for Prometheus.
 
 If you plan to collect and store events, collectd or Ceilometer delivers event data to the server side by using the {MessageBus} transport, delivering the data through the message bus. Another Smart Gateway writes the data to the ElasticSearch datastore.
 
 Server-side {ProjectShort} monitoring infrastructure consists of the following layers:
 
 * {Project} {ProductVersion} ({ProjectShort})
-* {OpenShift} {SupportedOpenShiftVersion} ({OpenShiftShort}) or {NextSupportedOpenShiftVersion}
+* {OpenShift} {SupportedOpenShiftVersion} or {NextSupportedOpenShiftVersion}
 * Infrastructure platform
 
 [[osp-stf-server-side-monitoring]]
@@ -71,10 +70,9 @@ image::STF_Overview_37_0819_deployment_prereq.png[Server-side STF monitoring inf
 
 
 [NOTE]
-Do not install {OpenShiftShort} on the same infrastructure that you want to monitor.
+Do not install {OpenShift} on the same infrastructure that you want to monitor.
 
 .Additional resources
 
-* For more information about how to deploy {OpenShift}, see the  https://access.redhat.com/documentation/en-us/openshift_container_platform/{SupportedOpenShiftVersion}/[{OpenShiftShort} product documentation].
-* You can install {OpenShiftShort} on cloud platforms or on bare metal.
-For more information about {ProjectShort} performance and scaling, see https://access.redhat.com/articles/4907241.
+* For more information about how to deploy {OpenShift}, see the  https://access.redhat.com/documentation/en-us/openshift_container_platform/{SupportedOpenShiftVersion}/[{OpenShift} product documentation].
+* You can install {OpenShift} on cloud platforms or on bare metal. For more information about {ProjectShort} performance and scaling, see https://access.redhat.com/articles/4907241.

--- a/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
@@ -62,9 +62,7 @@ If you plan to collect and store events, collectd or Ceilometer delivers event d
 Server-side {ProjectShort} monitoring infrastructure consists of the following layers:
 
 * {Project} {ProductVersion} ({ProjectShort})
-* {OpenShift} {SupportedOpenShiftVersion} ({OpenShiftShort}) 
-// TODO: add back to previous line when next version is supported
-// or {NextSupportedOpenShiftVersion}
+* {OpenShift} {SupportedOpenShiftVersion} ({OpenShiftShort}) or {NextSupportedOpenShiftVersion}
 * Infrastructure platform
 
 [[osp-stf-server-side-monitoring]]

--- a/doc-Service-Telemetry-Framework/modules/proc_adding-container-images-to-the-undercloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_adding-container-images-to-the-undercloud.adoc
@@ -1,0 +1,32 @@
+[id="adding-container-images-to-the-undercloud_{context}"]
+= Adding {OpenStack} container images to the undercloud
+
+[role="_abstract"]
+If you synchronized container images to a local registry, you must create an environment file and include the paths to the container images.
+
+
+
+.Procedure
+
+. Create a new environment file, for example, `container-images.yaml`, and insert the following container images and paths:
++
+[source,yaml,options="nowrap",role="white-space-pre"]
+----
+parameter_defaults:
+    DockerCollectdConfigImage: <image-registry-path>/rhosp{vernum}/openstack-collectd:latest
+    DockerCollectdImage: <image-registry-path>/rhosp{vernum}/openstack-collectd:latest
+    DockerMetricsQdrConfigImage: <image-registry-path>/rhosp{vernum}/openstack-qdrouterd:latest
+    DockerMetricsQdrImage: <image-registry-path>/rhosp{vernum}/openstack-qdrouterd:latest
+----
++
+Replace `<image-registry-path>` with the path to the image registry.
+
+. To deploy collectd and {MessageBus} to your overcloud, include the `/usr/share/local-container-images/container-images.yaml` environment file so {OpenStack} {OpenStackInstaller} can prepare the images. The following snippet is an example of how to include this environment file:
++
+[options="nowrap",role="white-space-pre"]
+----
+$ openstack overcloud container image prepare \
+  ...
+  -e /usr/share/local-container-images/container-images.yaml \
+  ...
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -46,7 +46,7 @@ ifdef::include_when_13[]
 * Replace the `caCertFileContent` parameter with the contents retrieved in xref:getting-ca-certificate-from-stf-for-overcloud-configuration_assembly-completing-the-stf-configuration[].
 endif::include_when_13[]
 +
-[source,yaml,options="nowrap",subs="+quotes"]
+[source,yaml,options="nowrap"]
 ----
 parameter_defaults:
     MetricsQdrConnectors:

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-route-in-ocp.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-route-in-ocp.adoc
@@ -47,7 +47,7 @@ $ oc project service-telemetry
 $ oc get services
 ----
 +
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
 NAME                                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
 alertmanager-operated                    ClusterIP   None             <none>        9093/TCP,9094/TCP,9094/UDP                      93m
@@ -64,7 +64,7 @@ smart-gateway-operator-metrics           ClusterIP   172.30.145.199   <none>    
 
 . Expose the `prometheus-operated` service as an edge route and redirect insecure traffic to the secure endpoint of port `9090`:
 +
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
 $ oc create route edge metrics-store --service=prometheus-operated --insecure-policy="Redirect" --port=9090
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -143,8 +143,9 @@ spec:
 $ oc logs --selector name=service-telemetry-operator
 ----
 +
-[options="nowrap"]
+[source,bash,options="nowrap"]
 ----
+
 --------------------------- Ansible Task Status Event StdOut  -----------------
 
 PLAY RECAP *********************************************************************

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -143,7 +143,7 @@ spec:
 $ oc logs --selector name=service-telemetry-operator
 ----
 +
-[options="nowrap", subs="+quotes"]
+[options="nowrap"]
 ----
 --------------------------- Ansible Task Status Event StdOut  -----------------
 
@@ -156,7 +156,7 @@ localhost                  : ok=54   changed=0    unreachable=0    failed=0    s
 NOTE: If you set `backends.events.elasticsearch.enabled: true`, the notification Smart Gateways reports `Error` and `CrashLoopBackOff` error messages for a period of time before ElasticSearch starts.
 
 +
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
 $ oc get pods
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -26,7 +26,7 @@
 = Creating a ServiceTelemetry object in {OpenShiftShort}
 
 [role="_abstract"]
-Create a `ServiceTelemetry` object in {OpenShiftShort} to result in the creation of supporting components for a {Project} deployment. For more information, see xref:overview-of-the-servicetelemetry-object[].
+Create a `ServiceTelemetry` object in {OpenShift} to result in the creation of supporting components for a {Project} deployment. For more information, see xref:primary-parameters-of-the-servicetelemetry-object[].
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -47,7 +47,12 @@ endif::include_when_13[]
 
 . Create a configuration file called `stf-connectors.yaml` in the `/home/stack` directory.
 
+ifdef::include_when_13[]
+. In the `stf-connectors.yaml` file, configure the `MetricsQdrConnectors` address to connect to the {MessageBus} on the overcloud deployment. Configure the `CeilometerQdrEventsConfig`, `CeilometerQdrMetricsConfig`, and `CollectdAmqpInstances` topic values to match the AMQP address that you want for this cloud deployment.
+endif::include_when_13[]
+ifdef::include_when_16[]
 . In the `stf-connectors.yaml` file, configure the `MetricsQdrConnectors` address to connect to the {MessageBus} on the overcloud deployment. Configure the `CeilometerQdrEventsConfig`, `CeilometerQdrMetricsConfig`, `CollectdAmqpInstances`, and `CollectdSensubilityResultsChannel` topic values to match the AMQP address that you want for this cloud deployment.
+endif::include_when_16[]
 +
 ifdef::include_when_13[]
 * Replace the `caCertFileContent` parameter with the contents retrieved in xref:getting-ca-certificate-from-stf-for-overcloud-configuration_assembly-completing-the-stf-configuration[].

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -97,7 +97,7 @@ endif::include_when_13[]
             presettle: false
         cloud1-telemetry:     # <6>
             format: JSON
-            presettle: true
+            presettle: false
 
 ifdef::include_when_16[]
     CollectdSensubilityResultsChannel: sensubility/cloud1-telemetry # <7>

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -36,10 +36,11 @@ endif::include_when_16[]
 ifdef::include_when_13[]
 * You have retrieved the CA certificate from the {MessageBus} deployed by {ProjectShort}. For more information, see xref:getting-ca-certificate-from-stf-for-overcloud-configuration_assembly-completing-the-stf-configuration[].
 endif::include_when_13[]
+* You have created your list of clouds objects. For more information about creating the content for the clouds parameter, see the xref:clouds_assembly-installing-the-core-components-of-stf[clouds configuration parameter].
+
 * You have retrieved the {MessageBus} route address. For more information, see xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
 * You have created the base configuration for {ProjectShort}. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration[].
 * You have created a unique domain name environment file. For more information, see xref:setting-a-unique-cloud-domain_assembly-completing-the-stf-configuration[].
-* You have created the `enable-stf.yaml` to set environment defaults for {ProjectShort}. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration[].
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -26,8 +26,10 @@
 [role="_abstract"]
 To label traffic according to the cloud of origin, you must create a configuration with cloud-specific instance names. Create an `stf-connectors.yaml` file and adjust the values of `CeilometerQdrEventsConfig`, `CeilometerQdrMetricsConfig` and `CollectdAmqpInstances` to match the AMQP address prefix scheme.
 
+ifdef::include_when_16[]
 [NOTE]
 If you enabled container health and API status monitoring, you must also modify the `CollectdSensubilityResultsChannel` parameter. For more information, see xref:monitoring-container-health-and-api-status_assembly-advanced-features[].
+endif::include_when_16[]
 
 .Prerequisites
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -123,6 +123,8 @@ endif::include_when_16[]
 [WARNING]
 If you use the `collectd-write-qdr.yaml` file with a custom `CollectdAmqpInstances` parameter, data publishes to the custom and default topics. In a multiple cloud environment, the configuration of the `resource_registry` parameter in the `stf-connectors.yaml` file loads the collectd service.
 +
+// valid use of +quotes subs for rendering emphasis
++
 [source,bash,options="nowrap",subs="+quotes"]
 ----
 (undercloud) [stack@undercloud-0 ~]$ openstack overcloud deploy _<other_arguments>_

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -56,9 +56,12 @@ endif::include_when_13[]
 .stf-connectors.yaml
 [source,yaml,options="nowrap"]
 ----
+resource_registry:
+  OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml    # <1>
+
 parameter_defaults:
     MetricsQdrConnectors:
-        - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch   # <1>
+        - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch   # <2>
           port: 443
           role: edge
           verifyHostname: false
@@ -75,32 +78,33 @@ endif::include_when_13[]
 
     CeilometerQdrEventsConfig:
         driver: amqp
-        topic: cloud1-event   # <2>
+        topic: cloud1-event   # <3>
 
     CeilometerQdrMetricsConfig:
         driver: amqp
-        topic: cloud1-metering   # <3>
+        topic: cloud1-metering   # <4>
 
     CollectdAmqpInstances:
-        cloud1-notify:        # <4>
+        cloud1-notify:        # <5>
             notify: true
             format: JSON
             presettle: false
-        cloud1-telemetry:     # <5>
+        cloud1-telemetry:     # <6>
             format: JSON
             presettle: true
 
 ifdef::include_when_16[]
-    CollectdSensubilityResultsChannel: collectd/cloud1-notify # <6>
+    CollectdSensubilityResultsChannel: sensubility/cloud1-telemetry # <7>
 endif::include_when_16[]
 ----
-<1> Replace the `host` parameter with the value of `HOST/PORT` that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
-<2> Define the topic for Ceilometer events. This value is the address format of `anycast/ceilometer/cloud1-event.sample`.
-<3> Define the topic for Ceilometer metrics. This value is the address format of `anycast/ceilometer/cloud1-metering.sample`.
-<4> Define the topic for collectd events. This value is the format of `collectd/cloud1-notify`.
-<5> Define the topic for collectd metrics. This value is the format of `collectd/cloud1-telemetry`.
+<1> Directly load the collectd service because you are not including the `collectd-write-qdr.yaml` environment file for multiple cloud deployments.
+<2> Replace the `host` parameter with the value of `HOST/PORT` that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
+<3> Define the topic for Ceilometer events. This value is the address format of `anycast/ceilometer/cloud1-event.sample`.
+<4> Define the topic for Ceilometer metrics. This value is the address format of `anycast/ceilometer/cloud1-metering.sample`.
+<5> Define the topic for collectd events. This value is the format of `collectd/cloud1-notify`.
+<6> Define the topic for collectd metrics. This value is the format of `collectd/cloud1-telemetry`.
 ifdef::include_when_16[]
-<6> Define the topic for collectd-sensubility events. Ensure that this value is the exact string format `collectd/cloud1-notify`
+<7> Define the topic for collectd-sensubility events. Ensure that this value is the exact string format `sensubility/cloud1-telemetry`
 endif::include_when_16[]
 +
 . Ensure that the naming convention in the `stf-connectors.yaml` file aligns with the `spec.bridge.amqpUrl` field in the Smart Gateway configuration. For example, configure the `CeilometerQdrEventsConfig.topic` field to a value of `cloud1-event`.
@@ -116,13 +120,15 @@ endif::include_when_16[]
 
 . Include the `stf-connectors.yaml` file and unique domain name environment file `hostnames.yaml` in the `openstack overcloud deployment` command, along with any other environment files relevant to your environment:
 +
+[WARNING]
+If you use the `collectd-write-qdr.yaml` file with a custom `CollectdAmqpInstances` parameter, data publishes to the custom and default topics. In a multiple cloud environment, the configuration of the `resource_registry` parameter in the `stf-connectors.yaml` file loads the collectd service.
++
 [source,bash,options="nowrap",subs="+quotes"]
 ----
 (undercloud) [stack@undercloud-0 ~]$ openstack overcloud deploy _<other_arguments>_
 --templates /usr/share/openstack-tripleo-heat-templates \
   --environment-file _<...other_environment_files...>_ \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
-  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-write-qdr.yaml \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml \
   --environment-file /home/stack/hostnames.yaml \
   --environment-file /home/stack/enable-stf.yaml \

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -90,6 +90,24 @@ parameter_defaults:
 
         # provide the human-friendly name of the virtual instance
         collectd::plugin::virt::plugin_instance_format: metadata
+
+        # set memcached collectd plugin to report its metrics by hostname
+        # rather than host IP, ensuring metrics in the dashboard remain uniform
+        collectd::plugin::memcached::instances:
+          local:
+            host: "%{hiera(fqdn_canonical)}"
+            port: 11211
+
+        # align defaults across OSP versions
+        collectd::plugin::cpu::reportbycpu: true
+        collectd::plugin::cpu::reportbystate: true
+        collectd::plugin::cpu::reportnumcpu: false
+        collectd::plugin::cpu::valuespercentage: true
+        collectd::plugin::df::ignoreselected: true
+        collectd::plugin::df::reportbydevice: true
+        collectd::plugin::df::fstypes: ['xfs']
+        collectd::plugin::load::reportrelative: true
+        collectd::plugin::virt::extra_stats: "pcpu cpu_util vcpupin vcpu memory disk disk_err disk_allocation disk_capacity disk_physical domain_state job_stats_background perf"
 ----
 endif::include_when_13[]
 ifdef::include_when_16[]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -135,6 +135,7 @@ parameter_defaults:
     # enable collection of API status
     CollectdEnableSensubility: true
     CollectdSensubilityTransport: amqp1
+    CollectdSensubilityResultsChannel: sensubility/telemetry
 
     # enable collection of containerized service metrics
     CollectdEnableLibpodstats: true

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -56,13 +56,19 @@ parameter_defaults:
     CeilometerQdrPublishMetrics: true
     CeilometerQdrPublishEvents: true
 
-    # set collectd overrides for higher telemetry resolution and extra plugins
-    # to load
+    # set collectd overrides for higher telemetry resolution and extra plugins to load
     CollectdConnectionType: amqp1
     CollectdAmqpInterval: 5
     CollectdDefaultPollingInterval: 5
     CollectdExtraPlugins:
     - vmem
+
+    # set standard prefixes for where metrics and events are published to QDR
+    MetricsQdrAddresses:
+    - prefix: 'collectd'
+      distribution: multicast
+    - prefix: 'anycast/ceilometer'
+      distribution: multicast
 
     ExtraConfig:
         ceilometer::agent::polling::polling_interval: 30
@@ -140,6 +146,13 @@ parameter_defaults:
     CollectdDefaultPollingInterval: 5
     CollectdExtraPlugins:
     - vmem
+
+    # set standard prefixes for where metrics and events are published to QDR
+    MetricsQdrAddresses:
+    - prefix: 'collectd'
+      distribution: multicast
+    - prefix: 'anycast/ceilometer'
+      distribution: multicast
 
     ExtraConfig:
         ceilometer::agent::polling::polling_interval: 30

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -128,9 +128,9 @@ parameter_defaults:
     ManagePolling: true
     ManagePipeline: true
 
-    # required to set valid parameter due to typo in ceilometer-write-qdr.yaml 
-    # and will be resolved in a future release
+    # enable Ceilometer metrics and events
     CeilometerQdrPublishMetrics: true
+    CeilometerQdrPublishEvents: true
 
     # enable collection of API status
     CollectdEnableSensubility: true

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -41,7 +41,7 @@ To enable collection of telemetry with {ProjectShort} and Gnocchi, see xref:send
 ====
 +
 ifdef::include_when_13[]
-[source,yaml,options="nowrap",subs="+quotes"]
+[source,yaml,options="nowrap"]
 ----
 parameter_defaults:
     # only send to STF, not other publishers
@@ -117,7 +117,7 @@ parameter_defaults:
 ----
 endif::include_when_13[]
 ifdef::include_when_16[]
-[source,yaml,options="nowrap",subs="+quotes"]
+[source,yaml,options="nowrap"]
 ----
 parameter_defaults:
     # only send to STF, not other publishers

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -37,7 +37,9 @@ To configure the base parameters to provide a compatible data collection and tra
 ====
 Setting `EventPipelinePublishers` and `PipelinePublishers` to empty lists results in no event or metric data passing to {OpenStack} legacy telemetry components, such as Gnocchi or Panko. If you need to send data to additional pipelines, the Ceilometer polling interval of 30 seconds as specified in `ExtraConfig` might overwhelm the legacy components, and should be increased to a larger value such as `300`. Increasing the value to a longer polling interval will result in less telemetry resolution in {ProjectShort}.
 
+ifdef::include_when_16[]
 To enable collection of telemetry with {ProjectShort} and Gnocchi, see xref:sending-metrics-to-gnocchi-and-to-stf_assembly-completing-the-stf-configuration[]
+endif::include_when_16[]
 ====
 +
 ifdef::include_when_13[]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -94,14 +94,11 @@ parameter_defaults:
         # receive extra information about virtual memory
         collectd::plugin::vmem::verbose: true
 
-        # provide the human-friendly name of the virtual instance
-        collectd::plugin::virt::plugin_instance_format: metadata
-
         # set memcached collectd plugin to report its metrics by hostname
         # rather than host IP, ensuring metrics in the dashboard remain uniform
         collectd::plugin::memcached::instances:
           local:
-            host: "%{hiera(fqdn_canonical)}"
+            host: "%{hiera('fqdn_canonical')}"
             port: 11211
 
         # align defaults across OSP versions

--- a/doc-Service-Telemetry-Framework/modules/proc_deleting-the-default-smart-gateways.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deleting-the-default-smart-gateways.adoc
@@ -26,7 +26,7 @@
 [role="_abstract"]
 After you configure {ProjectShort} for multiple clouds, you can delete the default Smart Gateways if they are no longer in use. The Service Telemetry Operator can remove `SmartGateway` objects that have been created but are no longer listed in the ServiceTelemetry `clouds` list of objects. To enable the removal of SmartGateway objects that are not defined by the `clouds` parameter, you must set the `cloudsRemoveOnMissing` parameter to `true` in the `ServiceTelemetry` manifest.
 
-TIP: If you do not want to deploy any Smart Gateways, define an empty clouds object by using the `clouds: {}` parameter.
+TIP: If you do not want to deploy any Smart Gateways, define an empty clouds list by using the `clouds: []` parameter.
 
 WARNING: The `cloudsRemoveOnMissing` parameter is disabled by default. If you enable the `cloudsRemoveOnMissing` parameter, you remove any manually created `SmartGateway` objects in the current namespace without any possibility to restore.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -24,7 +24,12 @@
 = Deploying Smart Gateways
 
 [role="_abstract"]
-You must deploy a Smart Gateway for each of the data collection types for each cloud; one for collectd metrics, one for collectd events, one for Ceilometer metrics, and one for Ceilometer events. Configure each of the Smart Gateways to listen on the AMQP address that you define for the corresponding cloud. Smart Gateways are defined via the `clouds` parameter in the `ServiceTelemetry` manifest.
+ifdef::include_when_16[]
+You must deploy a Smart Gateway for each of the data collection types for each cloud; one for collectd metrics, one for collectd events, one for Ceilometer metrics, one for Ceilometer events, and one for collectd-sensubility metrics. Configure each of the Smart Gateways to listen on the AMQP address that you define for the corresponding cloud. To define Smart Gateways, configure the `clouds` parameter in the `ServiceTelemetry` manifest.
+endif::include_when_16[]
+ifdef::include_when_13[]
+You must deploy a Smart Gateway for each of the data collection types for each cloud; one for collectd metrics, one for collectd events, one for Ceilometer metrics, and one for Ceilometer events. Configure each of the Smart Gateways to listen on the AMQP address that you define for the corresponding cloud. To define Smart Gateways, configure the `clouds` parameter in the `ServiceTelemetry` manifest.
+endif::include_when_13[]
 
 When you deploy {ProjectShort} for the first time, Smart Gateway manifests are created that define the initial Smart Gateways for a single cloud. When deploying Smart Gateways for multiple cloud support, you deploy multiple Smart Gateways for each of the data collection types that handle the metrics and the events data for each cloud. The initial Smart Gateways are defined under `cloud1` with the following subscription addresses:
 
@@ -32,6 +37,9 @@ When you deploy {ProjectShort} for the first time, Smart Gateway manifests are c
 | **collector** | **type** | **default subscription address**
 | collectd | metrics | collectd/telemetry
 | collectd | events | collectd/notify
+ifdef::include_when_16[]
+| collectd-sensubility | metrics | sensubility/telemetry
+endif::include_when_16[]
 | Ceilometer | metrics | anycast/ceilometer/metering.sample
 | Ceilometer | events | anycast/ceilometer/event.sample
 |===
@@ -84,6 +92,10 @@ spec:
       collectors:
       - collectorType: collectd
         subscriptionAddress: collectd/cloud1-telemetry
+ifdef::include_when_16[]
+      - collectorType: sensubility
+        subscriptionAddress: sensubility/cloud1-telemetry
+endif::include_when_16[]
       - collectorType: ceilometer
         subscriptionAddress: anycast/ceilometer/cloud1-metering.sample
   - name: cloud2
@@ -103,8 +115,11 @@ $ oc get po -l app=smart-gateway
 [source,bash]
 ----
 NAME                                                      READY   STATUS    RESTARTS   AGE
-default-cloud1-ceil-event-smartgateway-6cfb65478c-g5q82   1/1     Running   0          13h
-default-cloud1-ceil-meter-smartgateway-58f885c76d-xmxwn   1/1     Running   0          13h
-default-cloud1-coll-event-smartgateway-58fbbd4485-rl9bd   1/1     Running   0          13h
+default-cloud1-ceil-event-smartgateway-6cfb65478c-g5q82   2/2     Running   0          13h
+default-cloud1-ceil-meter-smartgateway-58f885c76d-xmxwn   2/2     Running   0          13h
+default-cloud1-coll-event-smartgateway-58fbbd4485-rl9bd   2/2     Running   0          13h
 default-cloud1-coll-meter-smartgateway-7c6fc495c4-jn728   2/2     Running   0          13h
+ifdef::include_when_16[]
+default-cloud1-sens-meter-smartgateway-8h4tc445a2-mm683   2/2     Running   0          13h
+endif::include_when_16[]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud.adoc
@@ -48,6 +48,8 @@ Deploy or update the overcloud with the required environment files to result in 
 * the `enable-stf.yaml` environment file to ensure defaults are set up correctly
 * the `stf-connectors.yaml` environment file to define the connection to {ProjectShort}
 +
+// this one is actually a valid use of subs +quotes. We want the underbars to result in emphasis when generated.
++
 [source,bash,options="nowrap",subs="+quotes"]
 ----
 (undercloud) [stack@undercloud-0 ~]$ openstack overcloud deploy _<other_arguments>_

--- a/doc-Service-Telemetry-Framework/modules/proc_enabling-infrawatch-catalog-source.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_enabling-infrawatch-catalog-source.adoc
@@ -54,7 +54,7 @@ EOF
 
 . Validate the creation of your CatalogSource:
 +
-[source,options="nowrap",subs="+quotes"]
+[source,options="nowrap"]
 ----
 $ oc get -nopenshift-marketplace catalogsource infrawatch-operators
 
@@ -67,7 +67,7 @@ infrawatch-operators   InfraWatch Operators   grpc   InfraWatch   2m16s
 . Validate that the Operators are available from the catalog:
 +
 
-[source,options="nowrap",subs="+quotes"]
+[source,options="nowrap"]
 ----
 $ oc get packagemanifests | grep InfraWatch
 

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -33,17 +33,25 @@ The Grafana Operator can import and manage dashboards by creating `GrafanaDashbo
 +
 [source,bash,options="nowrap"]
 ----
-$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/rhos-dashboard.yaml
+$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/stf-1.3/rhos-dashboard.yaml
 
-grafanadashboard.integreatly.org/rhos-dashboard created
+grafanadashboard.integreatly.org/rhos-dashboard-1.3 created
 ----
 . Import the cloud dashboard:
 +
 [source,bash,options="nowrap"]
 ----
-$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/rhos-cloud-dashboard.yaml
+$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/stf-1.3/rhos-cloud-dashboard.yaml
 
-grafanadashboard.integreatly.org/rhos-cloud-dashboard created
+grafanadashboard.integreatly.org/rhos-cloud-dashboard-1.3 created
+----
+. Import the cloud events dashboard:
++
+[source,bash,options="nowrap"]
+----
+$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/stf-1.3/rhos-cloudevents-dashboard.yaml
+
+grafanadashboard.integreatly.org/rhos-cloudevents-dashboard created
 ----
 +
 [WARNING]

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -57,15 +57,7 @@ grafanadashboard.integreatly.org/rhos-cloudevents-dashboard created
 ----
 +
 [WARNING]
-====
-Some panels in the cloud dashboard require that you set the collectd `virt` plugin parameter `hostname_format` to `name uuid hostname` in the stf-connectors.yaml file. If you do not configure this parameter, affected dashboards remain empty.
-[source,yaml]
-----
-parameter_defaults:
-    ExtraConfig:
-        collectd::plugin::virt::hostname_format: name uuid hostname
-----
-====
+For some panels in the cloud dashboard, you must set the value of the collectd `virt` plugin parameter `hostname_format` to `name uuid hostname` in the `stf-connectors.yaml` file. If you do not configure this parameter, affected dashboards remain empty. For more information about the `virt` plugin, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{vernum}/html-single/service_telemetry_framework_1.2/index#collectd-plugins_assembly[collectd plugins].
 
 . Verify that the dashboards are available:
 +
@@ -82,11 +74,11 @@ rhos-cloud-dashboard   7d21h
 +
 [source,bash,options="nowrap"]
 ----
-$ oc get route grafana-route -ojsonpath='{.spec.host}' 
+$ oc get route grafana-route -ojsonpath='{.spec.host}'
 
 grafana-route-service-telemetry.apps.infra.watch
 ----
 
-. Navigate to https://_<grafana_route_address>_ in a web browser. Replace _<grafana_route_address>_ with the value that you retrieved in the previous step.
+. In a web browser, navigate to https://_<grafana_route_address>_. Replace _<grafana_route_address>_ with the value that you retrieved in the previous step.
 
 . To view the dashboard, click *Dashboards* and *Manage*.

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -27,6 +27,8 @@
 [role="_abstract"]
 The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. You can view example dashboards at https://github.com/infrawatch/dashboards.
 
+WARNING: The dashboards are currently only compatible with a single cloud. If you use the dashboards when multiple clouds have been configured or if you change the address on the overcloud to which that metrics are sent, this can result in errors when you run the queries against Prometheus, such as `found duplicate series` errors.
+
 .Procedure
 
 . Import the infrastructure dashboard:

--- a/doc-Service-Telemetry-Framework/modules/proc_monitoring-container-health-and-api-status.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_monitoring-container-health-and-api-status.adoc
@@ -26,9 +26,7 @@
 [role="_abstract"]
 Container health assesses the status of each of the {OpenStack} service containers by periodically running a health check script using the OCI (Open Container Initiative) standard. Most {OpenStack} services implement a health check that logs issues and returns a binary status. For the {OpenStack} APIs, the health checks query the root endpoint and determine the health based on the response time.
 
-To monitor healthchecks in {Project} ({ProjectShort}), you must enable and configure the `collectd-sensubility` plugin to work with the `amqp1` protocol. The {ProjectShort} architecture considers healthcheck results to be events and they are stored in ElasticSearch.
-
-Container health monitoring is enabled by default in `enable-stf.yaml`. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration[].
+To monitor healthchecks in {Project} ({ProjectShort}), you must enable and configure the `collectd-sensubility` plugin to work with the `amqp1` protocol and configure the the amqp1 address. Container health monitoring is enabled by default in `enable-stf.yaml`. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration[].
 
 .Prerequisites
 

--- a/doc-Service-Telemetry-Framework/modules/proc_planning-amqp-address-prefixes.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_planning-amqp-address-prefixes.adoc
@@ -24,7 +24,26 @@
 = Planning AMQP address prefixes
 
 [role="_abstract"]
-By default, {OpenStack} nodes get data through two data collectors; collectd and Ceilometer. These components send telemetry data or notifications to the respective AMQP addresses, for example, `collectd/telemetry`, where {ProjectShort} Smart Gateways listen on those addresses for monitoring data. To support multiple clouds and to identify which cloud generated the monitoring data, configure each cloud to send data to a unique address. Prefix a cloud identifier to the second part of the address. The following list shows some example addresses and identifiers:
+
+ifdef::include_when_16[]
+By default, {OpenStack} nodes receive data through two data collectors; collectd and Ceilometer. The collectd-sensubility plugin requires a unique address. These components send telemetry data or notifications to the respective AMQP addresses, for example, `collectd/telemetry`. {ProjectShort} Smart Gateways listen on those AMQP addresses for monitoring data. To support multiple clouds and to identify which cloud generated the monitoring data, configure each cloud to send data to a unique address. Add a cloud identifier prefix to the second part of the address. The following list shows some example addresses and identifiers:
+
+* `collectd/cloud1-telemetry`
+* `collectd/cloud1-notify`
+* `sensubility/cloud1-telemetry`
+* `anycast/ceilometer/cloud1-metering.sample`
+* `anycast/ceilometer/cloud1-event.sample`
+* `collectd/cloud2-telemetry`
+* `collectd/cloud2-notify`
+* `sensubility/cloud2-telemetry`
+* `anycast/ceilometer/cloud2-metering.sample`
+* `anycast/ceilometer/cloud2-event.sample`
+* `collectd/us-east-1-telemetry`
+* `collectd/us-west-3-telemetry`
+endif::include_when_16[]
+
+ifdef::include_when_13[]
+By default, {OpenStack} nodes receive data through two data collectors; collectd and Ceilometer. These components send telemetry data or notifications to the respective AMQP addresses, for example, collectd/telemetry. {ProjectShort} Smart Gateways listen on the AMQP addresses for monitoring data. To support multiple clouds and to identify which cloud generated the monitoring data, configure each cloud to send data to a unique address. Add a cloud identifier prefix to the second part of the address. The following list shows some example addresses and identifiers:
 
 * `collectd/cloud1-telemetry`
 * `collectd/cloud1-notify`
@@ -36,3 +55,4 @@ By default, {OpenStack} nodes get data through two data collectors; collectd and
 * `anycast/ceilometer/cloud2-event.sample`
 * `collectd/us-east-1-telemetry`
 * `collectd/us-west-3-telemetry`
+endif::include_when_13[]

--- a/doc-Service-Telemetry-Framework/modules/proc_querying-metrics-data-from-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_querying-metrics-data-from-multiple-clouds.adoc
@@ -26,4 +26,4 @@
 [role="_abstract"]
 Data stored in Prometheus has a _service_ label attached according to the Smart Gateway it was scraped from. You can use this label to query data from a specific cloud.
 
-To query data from a specific cloud, use a Prometheus `promql` query that matches the associated _service_ label; for example: `collectd_uptime{service="default-cloud1-coll-meter-smartgateway"}`.
+To query data from a specific cloud, use a Prometheus `promql` query that matches the associated _service_ label; for example: `collectd_uptime{service="default-cloud1-coll-meter"}`.

--- a/doc-Service-Telemetry-Framework/modules/proc_removing-service-telemetry-framework-1-2-operators.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_removing-service-telemetry-framework-1-2-operators.adoc
@@ -1,0 +1,159 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+// This module can be included from assemblies using the following include statement:
+// include::<path>/proc_upgrading-service-telemetry-framework-to-version-1-3.adoc[leveloffset=+1]
+
+// The file name and the ID are based on the module title. For example:
+// * file name: proc_doing-procedure-a.adoc
+// * ID: [id='proc_doing-procedure-a_{context}']
+// * Title: = Doing procedure A
+//
+// The ID is used as an anchor for linking to the module. Avoid changing
+// it after the module has been published to ensure existing links are not
+// broken.
+//
+// The `context` attribute enables module reuse. Every module's ID includes
+// {context}, which ensures that the module has a unique ID even if it is
+// reused multiple times in a guide.
+//
+// Start the title with a verb, such as Creating or Create. See also
+// _Wording of headings_ in _The IBM Style Guide_.
+[id="removing-service-telemetry-framework-1-2-operators_{context}"]
+= Removing {Project} 1.2 Operators
+
+[role="_abstract"]
+Remove the Operators from {ProjectShort} v1.2, Smart Gateway Operator, and Service Telemetry Operator.
+
+[NOTE]
+You must temporarily remove the `clouds` parameters because of changes in the API interface. This results in the removal of all Smart Gateways until after the upgrade and the inability to deliver metrics and events during the upgrade.
+
+.Procedure
+
+. Retrieve the current `ServiceTelemetry` object and note the contents, in particular the `clouds` parameter because you must remove this parameter before you upgrade the Operators.
++
+[source,bash,options="nowrap"]
+----
+$ oc get stf default -oyaml
+----
+
+. Modify the ServiceTelemetry object to clear the `clouds` parameter and set it to an empty list. Set `cloudsRemoveOnMissing` to `true` to remove all Smart Gateways.
++
+WARNING: This command stops all monitoring functions until after the upgrade is completed and the `clouds` object is redefined. If you use the default clouds configuration, it is not defined in your ServiceTelemetry object.
++
+[source,bash,options="nowrap"]
+----
+$ oc patch stf default --patch $'spec:\n  clouds: []\n  cloudsRemoveOnMissing: true' --type=merge
+----
+
+. Monitor the Smart Gateway pods until they are fully terminated and removed:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pods --selector app=smart-gateway --watch
+
+NAME                                                      READY   STATUS    RESTARTS   AGE
+default-cloud1-ceil-meter-smartgateway-58cc854f4-hgk92    1/1     Running   0          2m42s
+default-cloud1-coll-meter-smartgateway-6c76f9786d-crn9b   2/2     Running   0          2m55s
+default-cloud1-coll-meter-smartgateway-6c76f9786d-crn9b   2/2     Terminating   0          3m12s
+default-cloud1-ceil-meter-smartgateway-58cc854f4-hgk92    1/1     Terminating   0          3m
+...
+
+----
+. Retrieve the `Subscription` name of the Smart Gateway Operator:
++
+[source,bash,options="nowrap"]
+----
+$ oc get sub smart-gateway-operator-stable-1.2-redhat-operators-openshift-marketplace
+
+NAME                                                                       PACKAGE                  SOURCE             CHANNEL
+smart-gateway-operator-stable-1.2-redhat-operators-openshift-marketplace   smart-gateway-operator   redhat-operators   stable-1.2
+----
+. Delete the Smart Gateway Operator subscription:
++
+[source,bash,options="nowrap"]
+----
+$ oc delete sub smart-gateway-operator-stable-1.2-redhat-operators-openshift-marketplace
+
+subscription.operators.coreos.com "smart-gateway-operator-stable-1.2-redhat-operators-openshift-marketplace" deleted
+----
+
+. Retrieve the Smart Gateway Operator ClusterServiceVersion:
++
+[source,bash,options="nowrap"]
+----
+$ oc get csv -o name | grep -E 'smart-gateway'
+
+clusterserviceversion.operators.coreos.com/smart-gateway-operator.v2.2.1623675667
+----
+
+. Delete the Smart Gateway Operator ClusterServiceVersion:
++
+[source,bash,options="nowrap"]
+----
+$ oc delete clusterserviceversion.operators.coreos.com/smart-gateway-operator.v2.2.1623675667
+
+clusterserviceversion.operators.coreos.com "smart-gateway-operator.v2.2.1623675667" deleted
+----
+
+. Delete the SmartGateway Custom Resource Definition:
++
+[source,bash,options="nowrap"]
+----
+$ oc delete crd smartgateways.smartgateway.infra.watch
+
+customresourcedefinition.apiextensions.k8s.io "smartgateways.smartgateway.infra.watch" deleted
+----
+
+. Patch the Service Telemetry Operator Subscription to use the stable-1.3 channel:
++
+[source,bash,options="nowrap"]
+----
+$ oc patch sub service-telemetry-operator --patch $'spec:\n  channel: stable-1.3' --type=merge
+
+subscription.operators.coreos.com/service-telemetry-operator patched
+----
+
+. Monitor the output of the `oc get csv` command until the Smart Gateway Operator is installed and Service Telemetry Operator is `Pending` for version 1.2 and 1.3:
++
+[source,bash,options="nowrap"]
+----
+$ oc get csv
+
+NAME                                         DISPLAY                                         VERSION          REPLACES                                     PHASE
+amq7-cert-manager.v1.0.0                     Red Hat Integration - AMQ Certificate Manager   1.0.0                                                         Succeeded
+amq7-interconnect-operator.v1.2.4            Red Hat Integration - AMQ Interconnect          1.2.4            amq7-interconnect-operator.v1.2.3            Succeeded
+elastic-cloud-eck.v1.6.0                     Elasticsearch (ECK) Operator                    1.6.0            elastic-cloud-eck.v1.5.0                     Succeeded
+prometheusoperator.0.47.0                    Prometheus Operator                             0.47.0           prometheusoperator.0.37.0                    Succeeded
+service-telemetry-operator.v1.2.1623675667   Service Telemetry Operator                      1.2.1623675667                                                Pending
+service-telemetry-operator.v1.3.1622734200   Service Telemetry Operator                      1.3.1622734200   service-telemetry-operator.v1.2.1623675667   Pending
+smart-gateway-operator.v3.0.1622734308       Smart Gateway Operator                          3.0.1622734308                                                Succeeded
+----
+
+. Delete the Service Telemetry Operator v1.2 ClusterServiceVersion:
++
+[source,bash,options="nowrap"]
+----
+$ oc delete csv service-telemetry-operator.v1.2.1623675667
+
+clusterserviceversion.operators.coreos.com "service-telemetry-operator.v1.2.1623675667" deleted
+----
+
+. Edit the ServiceTelemetry object and insert the contents of your previously noted `clouds` parameter. If the `clouds` parameter was not previously defined because you used the default Smart Gateway instances, remove the `clouds: []` parameter.
++
+[source,bash,options="nowrap"]
+----
+$ oc edit stf default
+----
+
+. Validate that the Smart Gateways have been restored:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pods --selector app=smart-gateway
+
+NAME                                                      READY   STATUS    RESTARTS   AGE
+default-cloud1-ceil-meter-smartgateway-6484b98b68-sl7mb   2/2     Running   0          5m56s
+default-cloud1-coll-meter-smartgateway-799f687658-nfzr6   2/2     Running   0          6m6s
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_removing-the-service-telemetry-framework-v1-1-catalogsource.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_removing-the-service-telemetry-framework-v1-1-catalogsource.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+// This module can be included from assemblies using the following include statement:
+// include::<path>/proc_removing-the-service-telemetry-framework-v1-1-catalogsource.adoc[leveloffset=+1]
+
+// The file name and the ID are based on the module title. For example:
+// * file name: proc_doing-procedure-a.adoc
+// * ID: [id='proc_doing-procedure-a_{context}']
+// * Title: = Doing procedure A
+//
+// The ID is used as an anchor for linking to the module. Avoid changing
+// it after the module has been published to ensure existing links are not
+// broken.
+//
+// The `context` attribute enables module reuse. Every module's ID includes
+// {context}, which ensures that the module has a unique ID even if it is
+// reused multiple times in a guide.
+//
+// Start the title with a verb, such as Creating or Create. See also
+// _Wording of headings_ in _The IBM Style Guide_.
+[id="removing-the-service-telemetry-framework-v1-1-catalogsource_{context}"]
+= Removing the Service Telemetry Framework v1.1 CatalogSource
+
+[role="_abstract"]
+Remove the {ProjectShort} v1.1 CatalogSource. {ProjectShort} v1.2 is shipped in the default-enabled redhat-operators CatalogSource.
+
+.Procedure
+
+* Delete the redhat-operators-stf CatalogSource:
++
+[source,bash,options="nowrap",subs="+quotes"]
+----
+$ oc delete catalogsource -nopenshift-marketplace redhat-operators-stf
+
+catalogsource.operators.coreos.com "redhat-operators-stf" deleted
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_sending-metrics-to-gnocchi-and-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_sending-metrics-to-gnocchi-and-to-stf.adoc
@@ -37,7 +37,7 @@ parameter_defaults:
 
 . Add the environment file `gnocchi-connectors.yaml` to the deployment command. Replace _<other_arguments>_ with files that are applicable to your environment.
 +
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
 $ openstack overcloud deploy _<other_arguments>_
 --templates /usr/share/openstack-tripleo-heat-templates \
@@ -52,7 +52,7 @@ $ openstack overcloud deploy _<other_arguments>_
 
 . To verify that the configuration was successful, verify the content of the file `/var/lib/config-data/puppet-generated/ceilometer/etc/ceilometer/pipeline.yaml` on a Controller node. Ensure that the `publishers` section of the file contains information for both notifier and Gnocchi.
 +
-[source,yaml,options="nowrap",subs="+quotes"]
+[source,yaml,options="nowrap"]
 ----
 sources:
     - name: meter_source

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -61,7 +61,7 @@ EOF
 
 . To verify that the operator launched successfully, run the `oc get csv` command. If the value of the PHASE column is `Succeeded`, the operator launched successfully:
 +
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
 $ oc get csv
 

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -59,7 +59,7 @@ spec:
 EOF
 ----
 
-. To verify that the operator launched successfully, run the `oc get csv` command. If the value of the PHASE column is `Succeeded`, the operator launched successfully:
+. To verify that the operator launched successfully, run the `oc get csv` command. In the command output, if the value of the `PHASE` column is `Succeeded`, the operator launched successfully:
 +
 [source,bash,options="nowrap"]
 ----
@@ -107,7 +107,7 @@ NAME                    AGE
 default-datasources     20h
 ----
 
-. Verify the Grafana route exists:
+. Verify that the Grafana route exists:
 +
 [source,bash,options="nowrap"]
 ----
@@ -117,5 +117,37 @@ NAME            HOST/PORT                                          PATH   SERVIC
 grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None
 ----
 
+. The dashboards in {ProjectShort} require features that are only available in Grafana version 8.1.0 and later. Ensure that you have the correct version of Grafana:
++
+[source,bash]
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
 
+docker.io/grafana/grafana:7.3.10
+----
 
+. If the running image is older than 8.1.0, patch the Grafana object to update the image:
++
+[source,bash,options="nowrap"]
+----
+$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
+----
++
+The Grafana deployment restarts.
+
+. Verify that a new Grafana pod exists and has a `STATUS` value of `Running`:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pod -l "app=grafana"
+NAME                                 READY     STATUS    RESTARTS   AGE
+grafana-deployment-fb9799b58-j2hj2   1/1       Running   0          10s
+----
+
+. Verify that the new instance is running the updated image:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
+docker.io/grafana/grafana:8.1.0
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-amq-certificate-manager-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-amq-certificate-manager-operator.adoc
@@ -43,7 +43,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: Red Hat STF Operators
-  image: quay.io/redhat-operators-stf/stf-catalog:v4.6
+  image: quay.io/redhat-operators-stf/stf-catalog:stable
   publisher: Red Hat
   sourceType: grpc
   updateStrategy:

--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-amq-certificate-manager-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-amq-certificate-manager-operator.adoc
@@ -75,7 +75,7 @@ EOF
 
 . Validate your `ClusterServiceVersion`:
 +
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
 $ oc get --namespace openshift-operators csv
 

--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-elastic-cloud-on-kubernetes-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-elastic-cloud-on-kubernetes-operator.adoc
@@ -49,7 +49,7 @@ EOF
 
 . Verify that the `ClusterServiceVersion` for ElasticSearch Cloud on Kubernetes `Succeeded`:
 +
-[source,options="nowrap",subs="+quotes"]
+[source,options="nowrap"]
 ----
 $ oc get csv
 

--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-service-telemetry-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-service-telemetry-operator.adoc
@@ -70,7 +70,7 @@ endif::[]
 
 . To validate the Service Telemetry Operator and the dependent operators, enter the following command:
 +
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
 $ oc get csv --namespace service-telemetry
 


### PR DESCRIPTION
- Jof vernum13 cp (#221)
- version 13->16.1 (#222) (#223)
- Align OSP13 base configuration for STF (#225) (#226)
- Use empty list vs object for clouds parameter (#232) (#234)
- Use the stable tag for STF CatalogSource (#231)
- Adjust multi-cloud config to avoid extra topics (#240) (#241)
- Updates for new sensubility amqp1 address (#239) (#242)
- Enable Ceilometer events (#244) (#245)
- Update dashboard import paths for stf-1.3 (#246) (#248)
- Allow better build controls in Makefile (#250) (#252)
- [STF 1.3] Upgrading from STF 1.2 to STF 1.3 (#235)
- stf13/cp 397391757009ee7ea94ebf0286329340e468a636 (#254)
- Minor fixes to OSP13 base configuration (#255) (#256)
- Minor fixes for formatting and version control (#257) (#258)
- Add back in note about support for OCP nextVersion (#259) (#260)
- Fix a broken link (#264)
- duplicate bullet point (#261)
- 1.3 cp 1866817 container images (#267)
- Add note about not supporting multiple clouds in the dashboards (#272) (#274)
- We should never set presettle to true (#275) (#276)
- Warn users that they may need to upgrade the Grafana image (#270) (#279)
- Jof cp mas 1999560 (#280)
- 1.3 cp 2002654 (#282)
- added upstream wrapper to Node tuning operator content (#285)
- Only show gnocchi + STF configuration for OSP16+
