### PR TITLE
Use ECK from Certified Operators CatalogSource

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-elastic-cloud-on-kubernetes-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-elastic-cloud-on-kubernetes-operator.adoc
@@ -28,7 +28,7 @@ Before you install the Service Telemetry Operator and if you plan to store event
 
 .Procedure
 
-. To enable the Elastic Cloud on Kubernetes Operator, create the following manifest in your {OpenShiftShort} environment:
+. To enable the Elastic Cloud on Kubernetes Operator, create the following manifest in your {OpenShift} environment:
 +
 [source,bash]
 ----
@@ -36,13 +36,13 @@ $ oc create -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: elastic-cloud-eck
+  name: elasticsearch-eck-operator-certified
   namespace: service-telemetry
 spec:
   channel: stable
   installPlanApproval: Automatic
-  name: elastic-cloud-eck
-  source: operatorhubio-operators
+  name: elasticsearch-eck-operator-certified
+  source: certified-operators
   sourceNamespace: openshift-marketplace
 EOF
 ----
@@ -53,7 +53,8 @@ EOF
 ----
 $ oc get csv
 
-NAME                       DISPLAY                        VERSION   REPLACES                   PHASE
+NAME                                          DISPLAY                        VERSION   REPLACES                                     PHASE
 ...
-elastic-cloud-eck.v1.6.0   Elasticsearch (ECK) Operator   1.6.0     elastic-cloud-eck.v1.5.0   Succeeded
+elasticsearch-eck-operator-certified.v1.7.1   Elasticsearch (ECK) Operator   1.7.1     elasticsearch-eck-operator-certified.v1.6.0  Succeeded
+...
 ----


### PR DESCRIPTION
Use the Elastic Cloud for Kubernetes Operator from the Certified
Operators CatalogSource instead of from OperatorHub.io

Cherry picked from commit eaa22c9978ecf77ccdc42e924a4326bbce1cbe1f
Resolves: rhbz#2002711
