### PR TITLE
Describe the sensubility Smart Gateway object in the ServiceTelemetry manifest (#301)

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
@@ -100,9 +100,9 @@ spec:
 
 Use the `clouds` parameter to control which Smart Gateway objects are deployed, thereby providing the interface for multiple monitored cloud environments to connect to an instance of {ProjectShort}. If a supporting backend is available, then metrics and events Smart Gateways for the default cloud configuration are created. By default, the Service Telemetry Operator creates Smart Gateways for `cloud1`.
 
-You can create a list of cloud objects to control which Smart Gateways are created for the defined clouds. Each cloud consists of data types and collectors. Data types are `metrics` or `events`. Each data type is made up of a list of collectors and the message bus subscription address. Available collectors are `collectd` and `ceilometer`. Ensure that the subscription address for each of these collectors is unique for every cloud, data type, and collector combination.
+You can create a list of cloud objects to control which Smart Gateways are created for the defined clouds. Each cloud consists of data types and collectors. Data types are `metrics` or `events`. Each data type is made up of a list of collectors, the message bus subscription address, and whether debugging is enabled. Available collectors for metrics are `collectd`, `ceilometer`, and `sensubility`. Available collectors for events are `collectd` and `ceilometer`. Ensure that the subscription address for each of these collectors is unique for every cloud, data type, and collector combination.
 
-The default `cloud1` configuration is represented by the following `ServiceTelemetry` object, providing subscriptions and data storage of metrics and events for both collectd and Ceilometer data collectors for a particular cloud instance:
+The default `cloud1` configuration is represented by the following `ServiceTelemetry` object, providing subscriptions and data storage of metrics and events for collectd, Ceilometer, and Sensubility data collectors for a particular cloud instance:
 
 [source,yaml]
 ----
@@ -120,6 +120,9 @@ spec:
             subscriptionAddress: collectd/telemetry
           - collectorType: ceilometer
             subscriptionAddress: anycast/ceilometer/metering.sample
+          - collectorType: sensubility
+            subscriptionAddress: sensubility/telemetry
+            debugEnabled: false
       events:
         collectors:
           - collectorType: collectd

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -126,6 +126,9 @@ spec:
           - collectorType: ceilometer
             subscriptionAddress: anycast/ceilometer/metering.sample
             debugEnabled: false
+          - collectorType: sensubility
+            subscriptionAddress: sensubility/telemetry
+            debugEnabled: false
       events:
         collectors:
           - collectorType: collectd
@@ -166,6 +169,7 @@ NAME                                                      READY   STATUS    REST
 alertmanager-default-0                                    2/2     Running   0          17m
 default-cloud1-ceil-meter-smartgateway-6484b98b68-vd48z   2/2     Running   0          17m
 default-cloud1-coll-meter-smartgateway-799f687658-4gxpn   2/2     Running   0          17m
+default-cloud1-sens-meter-smartgateway-c7f4f7fc8-c57b4    2/2     Running   0          17m
 default-interconnect-54658f5d4-pzrpt                      1/1     Running   0          17m
 elastic-operator-66b7bc49c4-sxkc2                         1/1     Running   0          52m
 interconnect-operator-69df6b9cb6-7hhp9                    1/1     Running   0          50m


### PR DESCRIPTION
* Describe the sensubility Smart Gateway object in the ServiceTelemetry manifest

Resolves rhbz#2008338

* Update doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc

* Update doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc

Cherry picked from commit a4eda658a8b64c215b039a6d2be61ca56c364660
Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>
