### PR TITLE
Update documentation to use graphing.grafana.baseImage

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -133,7 +133,7 @@ docker.io/grafana/grafana:7.3.10
 $ oc patch stf/default --type merge -p '{"spec":{"graphing":{"grafana":{"baseImage":"docker.io/grafana/grafana:8.1.5"}}}}'
 ----
 +
-Service Telemetry Operator will then update the Grafana manifest, resulting in the Grafana deployment restarting.
+Service Telemetry Operator updates the Grafana manifest, resulting in the Grafana deployment restarting.
 
 . Verify that a new Grafana pod exists and has a `STATUS` value of `Running`:
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -126,14 +126,14 @@ $ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
 docker.io/grafana/grafana:7.3.10
 ----
 
-. If the running image is older than 8.1.0, patch the Grafana object to update the image:
+. If the running image is older than 8.1.0, patch the ServiceTelemetry object to update the image:
 +
 [source,bash,options="nowrap"]
 ----
-$ oc patch grafana/default --type merge -p '{"spec":{"baseImage":"docker.io/grafana/grafana:8.1.0"}}'
+$ oc patch stf/default --type merge -p '{"spec":{"graphing":{"grafana":{"baseImage":"docker.io/grafana/grafana:8.1.5"}}}}'
 ----
 +
-The Grafana deployment restarts.
+Service Telemetry Operator will then update the Grafana manifest, resulting in the Grafana deployment restarting.
 
 . Verify that a new Grafana pod exists and has a `STATUS` value of `Running`:
 +


### PR DESCRIPTION
Update the documentation to use the built in baseImage configuration
within the graphing parameter of the ServiceTelemetry object instead of
patching the Grafana object directly.

Resolves: STF-597
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
