### PR TITLE
Clean up after installation walk through (#312)

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -72,10 +72,8 @@ metadata:
   name: default
 spec:
   alerting:
-    enabled: true
     alertmanager:
       storage:
-        strategy: persistent
         persistent:
           pvcStorageRequest: 20G
           storageSelector: {}
@@ -83,25 +81,27 @@ spec:
           snmpTraps:
             enabled: false
             target: 192.168.24.254
+        strategy: persistent
+    enabled: true
   backends:
     events:
       elasticsearch:
         enabled: false
         storage:
-          strategy: persistent
           persistent:
             pvcStorageRequest: 20Gi
             storageSelector: {}
+          strategy: persistent
     metrics:
       prometheus:
         enabled: true
         scrapeInterval: 10s
         storage:
-          strategy: persistent
           persistent:
             pvcStorageRequest: 20G
             storageSelector: {}
           retention: 24h
+          strategy: persistent
   graphing:
     enabled: false
     grafana:
@@ -109,6 +109,7 @@ spec:
       adminUser: root
       disableSignoutMenu: false
       ingressEnabled: false
+      baseImage: docker.io/grafana/grafana:8.1.2
   highAvailability:
     enabled: false
   transports:
@@ -152,7 +153,7 @@ $ oc logs --selector name=service-telemetry-operator
 --------------------------- Ansible Task Status Event StdOut  -----------------
 
 PLAY RECAP *********************************************************************
-localhost                  : ok=54   changed=0    unreachable=0    failed=0    skipped=19   rescued=0    ignored=0
+localhost                  : ok=57   changed=0    unreachable=0    failed=0    skipped=20   rescued=0    ignored=0
 ----
 
 .Verification

--- a/doc-Service-Telemetry-Framework/modules/proc_enabling-the-operatorhub-io-community-catalog-source.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_enabling-the-operatorhub-io-community-catalog-source.adoc
@@ -50,3 +50,23 @@ spec:
   publisher: OperatorHub.io
 EOF
 ----
+
+* Validate your `CatalogSource`:
++
+[source,bash]
+----
+$ oc get catalogsource -nopenshift-marketplace operatorhubio-operators
+
+NAME                      DISPLAY                    TYPE   PUBLISHER        AGE
+operatorhubio-operators   OperatorHub.io Operators   grpc   OperatorHub.io   2m21s
+----
+
+* Verify that the `operatorhubio-operators` pod is running:
++
+[source,bash]
+----
+$ oc get pods -nopenshift-marketplace --selector olm.catalogSource=operatorhubio-operators
+
+NAME                            READY   STATUS    RESTARTS   AGE
+operatorhubio-operators-2cmm4   1/1     Running   0          3m12s
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -63,12 +63,10 @@ EOF
 +
 [source,bash,options="nowrap"]
 ----
-$ oc get csv
+$ oc get csv --selector operators.coreos.com/grafana-operator.service-telemetry
 
-NAME                                DISPLAY                                         VERSION   REPLACES                            PHASE
-grafana-operator.v3.10.3            Grafana Operator                                3.10.3    grafana-operator.v3.10.2            Succeeded
-
-...
+NAME                       DISPLAY            VERSION   REPLACES                   PHASE
+grafana-operator.v3.10.3   Grafana Operator   3.10.3    grafana-operator.v3.10.2   Succeeded
 ----
 
 . To launch a Grafana instance, create or modify the `ServiceTelemetry` object. Set `graphing.enabled` and `graphing.grafana.ingressEnabled` to `true`.

--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-elastic-cloud-on-kubernetes-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-elastic-cloud-on-kubernetes-operator.adoc
@@ -51,10 +51,8 @@ EOF
 +
 [source,options="nowrap"]
 ----
-$ oc get csv
+$ oc get csv --selector operators.coreos.com/elasticsearch-eck-operator-certified.service-telemetry
 
-NAME                                          DISPLAY                        VERSION   REPLACES                                     PHASE
-...
-elasticsearch-eck-operator-certified.v1.7.1   Elasticsearch (ECK) Operator   1.7.1     elasticsearch-eck-operator-certified.v1.6.0  Succeeded
-...
+NAME                                          DISPLAY                        VERSION   REPLACES                                      PHASE
+elasticsearch-eck-operator-certified.v1.8.0   Elasticsearch (ECK) Operator   1.8.0     elasticsearch-eck-operator-certified.v1.7.1   Succeeded
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-service-telemetry-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-service-telemetry-operator.adoc
@@ -74,8 +74,9 @@ endif::[]
 ----
 $ oc get csv --namespace service-telemetry
 
+NAME                                          DISPLAY                                         VERSION          REPLACES                                      PHASE
 amq7-cert-manager.v1.0.1                      Red Hat Integration - AMQ Certificate Manager   1.0.1                                                          Succeeded
-amq7-interconnect-operator.v1.10.1            Red Hat Integration - AMQ Interconnect          1.10.1           amq7-interconnect-operator.v1.2.4             Succeeded
+amq7-interconnect-operator.v1.10.2            Red Hat Integration - AMQ Interconnect          1.10.2                                                         Succeeded
 elasticsearch-eck-operator-certified.v1.8.0   Elasticsearch (ECK) Operator                    1.8.0            elasticsearch-eck-operator-certified.v1.7.1   Succeeded
 prometheusoperator.0.47.0                     Prometheus Operator                             0.47.0           prometheusoperator.0.37.0                     Succeeded
 service-telemetry-operator.v1.3.1632925572    Service Telemetry Operator                      1.3.1632925572                                                 Succeeded


### PR DESCRIPTION
* Clean up after installation walk through

Do a bit of clean up and verification refactoring after doing a
documentation walk through.

* Grafana Operator CSV check clean up

* Update doc-Service-Telemetry-Framework/modules/proc_enabling-the-operatorhub-io-community-catalog-source.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-service-telemetry-operator.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>
Cherry picked from commit 0a405127872d1655ad9a472f4211554c44699c6a
