### PR TITLE
Increase supported version range of STF (#329)

### DIFF
--- a/common/stf-attributes.adoc
+++ b/common/stf-attributes.adoc
@@ -34,7 +34,7 @@ ifeval::["{build}" == "upstream"]
 :ProjectShort: STF
 :MessageBus: Apache{nbsp}Qpid{nbsp}Dispatch{nbsp}Router
 :SupportedOpenShiftVersion: 4.6
-:NextSupportedOpenShiftVersion: 4.7
+:NextSupportedOpenShiftVersion: 4.8
 endif::[]
 
 ifeval::["{build}" == "downstream"]
@@ -51,5 +51,5 @@ ifeval::["{build}" == "downstream"]
 :ProjectShort: STF
 :MessageBus: AMQ{nbsp}Interconnect
 :SupportedOpenShiftVersion: 4.6
-:NextSupportedOpenShiftVersion: 4.7
+:NextSupportedOpenShiftVersion: 4.8
 endif::[]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
@@ -22,7 +22,7 @@ You can use Operators to load the {Project} ({ProjectShort}) components and obje
 
 ifeval::["{build}" == "downstream"]
 [IMPORTANT]
-{ProjectShort} is compatible with {OpenShift} version {SupportedOpenShiftVersion} through to {NextSupportedOpenShiftVersion}.
+{ProjectShort} is compatible with {OpenShift} version {SupportedOpenShiftVersion} through {NextSupportedOpenShiftVersion}.
 endif::[]
 
 .Additional resources

--- a/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
@@ -75,7 +75,7 @@ If you plan to collect and store events, collectd and Ceilometer deliver event d
 Server-side {ProjectShort} monitoring infrastructure consists of the following layers:
 
 * {Project} {ProductVersion}
-* {OpenShift} {SupportedOpenShiftVersion} or {NextSupportedOpenShiftVersion}
+* {OpenShift} {SupportedOpenShiftVersion} through {NextSupportedOpenShiftVersion}
 * Infrastructure platform
 
 [[osp-stf-server-side-monitoring]]


### PR DESCRIPTION
STF now supports OCP versions 4.6 through 4.8.

Cherry picked from commit db567a219687a16b33a5302b100612f0080eb624
