### PR TITLE
Rework the dashboard setup (#335)

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
@@ -22,6 +22,7 @@ endif::include_when_16[]
 include::../modules/con_dashboards.adoc[leveloffset=+1]
 include::../modules/proc_setting-up-grafana-to-host-the-dashboard.adoc[leveloffset=+2]
 ifdef::include_when_16[]
+include::../modules/proc_overriding-the-default-grafana-container-image.adoc[leveloffset=+2]
 //TODO: Add dashboards back when we have working code for OSP13
 include::../modules/proc_importing-dashboards.adoc[leveloffset=+2]
 endif::include_when_16[]

--- a/doc-Service-Telemetry-Framework/modules/con_dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_dashboards.adoc
@@ -14,7 +14,7 @@ Infrastructure dashboard::
 Use the infrastructure dashboard to view metrics for a single node at a time. Select a node from the upper left corner of the dashboard.
 
 Cloud view dashboard::
-Use the cloud view dashboard to view panels to monitor service resource usage, API stats, and cloud events. You must enable API health monitoring and service monitoring to provide the data for this dashboard. API health monitoring is enabled by default in the {ProjectShort} base configuration. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration
+Use the cloud view dashboard to view panels to monitor service resource usage, API stats, and cloud events. You must enable API health monitoring and service monitoring to provide the data for this dashboard. API health monitoring is enabled by default in the {ProjectShort} base configuration. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration[].
 ** For more information about API health monitoring, see xref:container-health-and-api-status_assembly-advanced-features[].
 ** For more information about {OpenStackShort} service monitoring, see xref:resource-usage-of-openstack-services_assembly-advanced-features[].
 endif::include_when_16[]

--- a/doc-Service-Telemetry-Framework/modules/proc_overriding-the-default-grafana-container-image.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_overriding-the-default-grafana-container-image.adoc
@@ -1,0 +1,38 @@
+[id="overriding-the-default-grafana-container-image_{context}"]
+= Overriding the default Grafana container image
+
+The dashboards in {Project} ({ProjectShort}) require features that are available only in Grafana version 8.1.0 and later. By default, the Service Telemetry Operator installs a compatible version. You can override the base Grafana image by specifying the image path to an image registry with `graphing.grafana.baseImage`.
+
+.Procedure
+
+. Ensure that you have the correct version of Grafana:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
+docker.io/grafana/grafana:7.3.10
+----
+
+. If the running image is older than 8.1.0, patch the ServiceTelemetry object to update the image. Service Telemetry Operator updates the Grafana manifest, which restarts the Grafana deployment:
++
+[source,bash,options="nowrap"]
+----
+$ oc patch stf/default --type merge -p '{"spec":{"graphing":{"grafana":{"baseImage":"docker.io/grafana/grafana:8.1.5"}}}}'
+----
+
+. Verify that a new Grafana pod exists and has a `STATUS` value of `Running`:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pod -l "app=grafana"
+NAME                                 READY     STATUS    RESTARTS   AGE
+grafana-deployment-fb9799b58-j2hj2   1/1       Running   0          10s
+----
+
+. Verify that the new instance is running the updated image:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
+docker.io/grafana/grafana:8.1.0
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -4,6 +4,8 @@
 [role="_abstract"]
 Grafana is not included in the default {Project} ({ProjectShort}) deployment so you must deploy the Grafana Operator from OperatorHub.io. When you use the Service Telemetry Operator to deploy Grafana, it results in a Grafana instance and the configuration of the default data sources for the local {ProjectShort} deployment.
 
+ifdef::include_16[The dashboards in {ProjectShort} require features that are available only in Grafana version 8.1.0 and later. By default, the Service Telemetry Operator installs a compatible version. For more information about how to override the Grafana container image, see xref:overriding-the-default-grafana-container-image_assembly-advanced-features[].]
+
 .Procedure
 
 . Log in to {OpenShift}.
@@ -88,38 +90,4 @@ $ oc get route grafana-route
 
 NAME            HOST/PORT                                          PATH   SERVICES          PORT   TERMINATION   WILDCARD
 grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None
-----
-
-. The dashboards in {ProjectShort} require features that are available only in Grafana version 8.1.0 and later. Ensure that you have the correct version of Grafana:
-+
-[source,bash]
-----
-$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
-
-docker.io/grafana/grafana:7.3.10
-----
-
-. If the running image is older than 8.1.0, patch the ServiceTelemetry object to update the image. Service Telemetry Operator updates the Grafana manifest, which restarts the Grafana deployment:
-+
-[source,bash,options="nowrap"]
-----
-$ oc patch stf/default --type merge -p '{"spec":{"graphing":{"grafana":{"baseImage":"docker.io/grafana/grafana:8.1.5"}}}}'
-----
-+
-
-. Verify that a new Grafana pod exists and has a `STATUS` value of `Running`:
-+
-[source,bash,options="nowrap"]
-----
-$ oc get pod -l "app=grafana"
-NAME                                 READY     STATUS    RESTARTS   AGE
-grafana-deployment-fb9799b58-j2hj2   1/1       Running   0          10s
-----
-
-. Verify that the new instance is running the updated image:
-+
-[source,bash,options="nowrap"]
-----
-$ oc get pod -l "app=grafana" -ojsonpath='{.items[0].spec.containers[0].image}'
-docker.io/grafana/grafana:8.1.0
 ----


### PR DESCRIPTION
* Rework the dashboard setup

Reword the dashboard setup to break out the image override section. Make
that a separate procedure and reference it from the base deployment. A
compatible version of Grafana is already deployed by default.

* Dashboards are not provided as part of OSP13 deployments

* Update doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_overriding-the-default-grafana-container-image.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>