### PR TITLE
Add clarification for backends persistent storage (#340)

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
@@ -29,14 +29,10 @@ endif::[]
 
 * For more information about Operators, see the https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/operators/olm-what-operators-are.html[_Understanding Operators_] guide.
 
-
 include::../modules/proc_deploying-stf-to-the-openshift-environment.adoc[leveloffset=+1]
-
-
 include::../modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc[leveloffset=+1]
 include::../modules/con_primary-parameters-of-the-servicetelemetry-object.adoc[leveloffset=+2]
 include::../modules/proc_removing-stf-from-the-openshift-environment.adoc[leveloffset=+1]
-
 
 //reset the context
 ifdef::parent-context[:context: {parent-context}]

--- a/doc-Service-Telemetry-Framework/modules/con_persistent-volumes.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_persistent-volumes.adoc
@@ -2,7 +2,7 @@
 = Persistent volumes
 
 [role="_abstract"]
-{Project} ({ProjectShort}) uses persistent storage in {OpenShift} to instantiate volumes dynamically so that Prometheus and ElasticSearch can store metrics and events.
+{Project} ({ProjectShort}) uses persistent storage in {OpenShift} to request persistent volumes so that Prometheus and ElasticSearch can store metrics and events.
 
 When you enable persistent storage through the Service Telemetry Operator, the Persistent Volume Claims (PVC) requested in an {ProjectShort} deployment results in an access mode of RWO (ReadWriteOnce). If your environment contains pre-provisioned persistent volumes, ensure that volumes of RWO are available in the {OpenShift} default configured `storageClass`.
 
@@ -10,3 +10,7 @@ When you enable persistent storage through the Service Telemetry Operator, the P
 * For more information about configuring persistent storage for {OpenShift}, see https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/storage/understanding-persistent-storage.html[Understanding persistent storage.]
 
 * For more information about recommended configurable storage technology in {OpenShift}, see https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/scalability_and_performance/optimizing-storage.html#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology].
+
+* For more information about configuring persistent storage for Prometheus in {ProjectShort}, see xref:backends-configuring-persistent-storage-for-prometheus_assembly-installing-the-core-components-of-stf[].
+
+* For more information about configuring persistent storage for ElasticSearch in {ProjectShort}, see xref:backends-configuring-persistent-storage-for-elasticsearch_assembly-installing-the-core-components-of-stf[].

--- a/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
@@ -1,4 +1,4 @@
-[id="primary-parameters-of-the-servicetelemetry-object"]
+[id="primary-parameters-of-the-servicetelemetry-object_{context}"]
 = Primary parameters of the ServiceTelemetry object
 
 [role="_abstract"]
@@ -20,6 +20,7 @@ Support for `servicetelemetry.infra.watch/v1alpha1` was removed from {ProjectSho
 ====
 
 [id="backends_{context}"]
+[discrete]
 == The backends parameter
 
 Use the `backends` parameter to control which storage back ends are available for storage of metrics and events, and to control the enablement of Smart Gateways that the `clouds` parameter defines. For more information, see xref:clouds_assembly-installing-the-core-components-of-stf[].
@@ -49,6 +50,50 @@ spec:
         enabled: true
 ----
 
+[id="backends-configuring-persistent-storage-for-prometheus_{context}"]
+[discrete]
+=== Configuring persistent storage for Prometheus
+
+Use the additional parameters that are defined in `backends.metrics.prometheus.storage.persistent` to configure persistent storage options for Prometheus, such as storage class and volume size.
+
+Use `storageClass` to define the back end storage class. If you do not set this parameter, the Service Telemetry Operator uses the default storage class for the {OpenShift} cluster.
+
+Use the `pvcStorageRequest` parameter to define the minimum required volume size to satisfy the storage request. If volumes are statically defined, it is possible that a volume size larger than requested is used. By default, Service Telemetry Operator requests a volume size of `20G` (20 Gigabytes).
+
+.Procedure
+
+* List the available storage classes:
++
+[source,bash,options="nowrap"]
+----
+$ oc get storageclasses
+NAME                 PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+csi-manila-ceph      manila.csi.openstack.org   Delete          Immediate              false                  20h
+standard (default)   kubernetes.io/cinder       Delete          WaitForFirstConsumer   true                   20h
+standard-csi         cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   20h
+----
+
+* Configure the `ServiceTelemetry` object:
++
+[source,yaml]
+----
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+  backends:
+    metrics:
+      prometheus:
+        enabled: true
+        storage:
+          strategy: persistent
+          persistent:
+            storageClass: standard-csi
+            pvcStorageRequest: 50G
+----
+
 [discrete]
 === Enabling ElasticSearch as a storage back end for events
 
@@ -70,6 +115,50 @@ spec:
     events:
       elasticsearch:
         enabled: true
+----
+
+[id="backends-configuring-persistent-storage-for-elasticsearch_{context}"]
+[discrete]
+=== Configuring persistent storage for ElasticSearch
+
+Use the additional parameters defined in `backends.events.elasticsearch.storage.persistent` to configure persistent storage options for ElasticSearch, such as storage class and volume size.
+
+Use `storageClass` to define the back end storage class. If you do not set this parameter, the Service Telemetry Operator uses the default storage class for the {OpenShift} cluster.
+
+Use the `pvcStorageRequest` parameter to define the minimum required volume size to satisfy the storage request. If volumes are statically defined, it is possible that a volume size larger than requested is used. By default, Service Telemetry Operator requests a volume size of `20Gi` (20 Gibibytes).
+
+.Procedure
+
+* List the available storage classes:
++
+[source,bash,options="nowrap"]
+----
+$ oc get storageclasses
+NAME                 PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+csi-manila-ceph      manila.csi.openstack.org   Delete          Immediate              false                  20h
+standard (default)   kubernetes.io/cinder       Delete          WaitForFirstConsumer   true                   20h
+standard-csi         cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   20h
+----
+
+* Configure the `ServiceTelemetry` object:
++
+[source,yaml]
+----
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+  backends:
+    events:
+      elasticsearch:
+        enabled: true
+        storage:
+          strategy: persistent
+          persistent:
+            storageClass: standard-csi
+            pvcStorageRequest: 50G
 ----
 
 [id="clouds_{context}"]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -2,7 +2,7 @@
 = Creating a ServiceTelemetry object in {OpenShift}
 
 [role="_abstract"]
-Create a `ServiceTelemetry` object in {OpenShift} to result in the Service Telemetry Operator creating the supporting components for a {Project} ({ProjectShort}) deployment. For more information, see xref:primary-parameters-of-the-servicetelemetry-object[].
+Create a `ServiceTelemetry` object in {OpenShift} to result in the Service Telemetry Operator creating the supporting components for a {Project} ({ProjectShort}) deployment. For more information, see xref:primary-parameters-of-the-servicetelemetry-object_assembly-installing-the-core-components-of-stf[].
 
 .Procedure
 


### PR DESCRIPTION
* Add clarification for backends persistent storage

Clarify that a dynamically created persistent volume is not required for
STF, but rather that persistent volumes are requested with a PVC, but
that statically defined volumes will still work. Add procedures and
links to show how to configure different storageClasses and the
requested volume size via PVC for the supported storage backends.

* Update doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc

* Update doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc

* Update doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc

* Update doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc

* Update doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc

* Update doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>