### PR TITLE
Use openstack-monitoring as the default namespace

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc
@@ -21,6 +21,8 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 To migrate from {Project} ({ProjectShort}) v1.2 to {ProjectShort} v1.3, you must replace the `ClusterServiceVersion` and `Subscription` objects in the `service-telemetry` namespace on your {OpenShift} ({OpenShiftShort}) environment.
 
+NOTE: The default namespace in {ProjectShort} v1.3 and earlier used `service-telemetry`, but has changed to `openstack-monitoring` in subsequent releases. {ProjectShort} can be installed to any namespace, and the existing namespace `service-telemetry` has been maintained for the purposes of upgrade documentation.
+
 .Prerequisites
 
 * You have upgraded your {OpenShiftShort} environment to v4.6. {ProjectShort} v1.3 does not run on {OpenShiftShort} v4.5 and lower. {ProjectShort} v1.2 does not run on {OpenShiftShort} v4.7 and higher.

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-3.adoc
@@ -21,7 +21,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 To migrate from {Project} ({ProjectShort}) v1.2 to {ProjectShort} v1.3, you must replace the `ClusterServiceVersion` and `Subscription` objects in the `service-telemetry` namespace on your {OpenShift} ({OpenShiftShort}) environment.
 
-NOTE: The default namespace in {ProjectShort} v1.3 and earlier used `service-telemetry`, but has changed to `openstack-monitoring` in subsequent releases. {ProjectShort} can be installed to any namespace, and the existing namespace `service-telemetry` has been maintained for the purposes of upgrade documentation.
+NOTE: The default namespace in {ProjectShort} v1.3 and earlier used `service-telemetry`, but has changed to `openstack-monitoring` in subsequent releases. You can install {ProjectShort} to any namespace, and the existing namespace `service-telemetry` is maintained for the purposes of upgrade documentation.
 
 .Prerequisites
 

--- a/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
@@ -42,7 +42,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   backends:
     metrics:
@@ -81,7 +81,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   backends:
     metrics:
@@ -109,7 +109,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   backends:
     events:
@@ -148,7 +148,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   backends:
     events:
@@ -177,7 +177,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: stf-default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   clouds:
     - name: cloud1

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-ephemeral-storage.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-ephemeral-storage.adoc
@@ -7,11 +7,11 @@ To configure {ProjectShort} components for ephemeral storage, add `...storage.st
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
 . Edit the ServiceTelemetry object:
@@ -29,7 +29,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: stf-default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   alerting:
     enabled: true

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-high-availability.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-high-availability.adoc
@@ -8,11 +8,11 @@ To configure {Project} ({ProjectShort}) for high availability, add `highAvailabi
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
 . Use the oc command to edit the ServiceTelemetry object:

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -29,7 +29,7 @@ endif::include_when_13[]
 ----
 parameter_defaults:
     MetricsQdrConnectors:
-    - host: default-interconnect-5671-service-telemetry.apps.infra.watch
+    - host: default-interconnect-5671-openstack-monitoring.apps.infra.watch
       port: 443
       role: edge
       sslProfile: sslProfile

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-route-in-ocp.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-route-in-ocp.adoc
@@ -11,27 +11,32 @@ A common service to expose in {ProjectShort} is Prometheus, as shown in the foll
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
-. List the available services in the `service-telemetry` project:
+. List the available services in the namespace:
 +
 [source,bash,options="nowrap"]
 ----
 $ oc get services
-NAME                                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
-alertmanager-operated                    ClusterIP   None             <none>        9093/TCP,9094/TCP,9094/UDP                      93m
-default-cloud1-ceil-meter-smartgateway   ClusterIP   172.30.114.195   <none>        8081/TCP                                        93m
-default-cloud1-coll-meter-smartgateway   ClusterIP   172.30.133.180   <none>        8081/TCP                                        93m
-default-interconnect                     ClusterIP   172.30.3.241     <none>        5672/TCP,8672/TCP,55671/TCP,5671/TCP,5673/TCP   93m
-ibm-auditlogging-operator-metrics        ClusterIP   172.30.216.249   <none>        8383/TCP,8686/TCP                               11h
-prometheus-operated                      ClusterIP   None             <none>        9090/TCP                                        93m
-service-telemetry-operator-metrics       ClusterIP   172.30.11.66     <none>        8383/TCP,8686/TCP                               11h
-smart-gateway-operator-metrics           ClusterIP   172.30.145.199   <none>        8383/TCP,8686/TCP                               11h
+NAME                                               TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
+alertmanager-operated                              ClusterIP   None             <none>        9093/TCP,9094/TCP,9094/UDP                      16m
+controller-manager-metrics-service                 ClusterIP   172.30.103.103   <none>        8443/TCP                                        16m
+default-cloud1-ceil-meter                          ClusterIP   172.30.223.139   <none>        8081/TCP                                        15m
+default-cloud1-coll-meter                          ClusterIP   172.30.229.199   <none>        8081/TCP                                        15m
+default-cloud1-sens-meter                          ClusterIP   172.30.39.80     <none>        8081/TCP                                        15m
+default-interconnect                               ClusterIP   172.30.65.91     <none>        5672/TCP,8672/TCP,55671/TCP,5671/TCP,5673/TCP   16m
+default-prometheus-webhook-snmp                    ClusterIP   172.30.230.0     <none>        9099/TCP                                        15m
+elasticsearch-es-default                           ClusterIP   None             <none>        9200/TCP                                        15m
+elasticsearch-es-http                              ClusterIP   172.30.155.241   <none>        9200/TCP                                        15m
+elasticsearch-es-transport                         ClusterIP   None             <none>        9300/TCP                                        15m
+prometheus-operated                                ClusterIP   None             <none>        9090/TCP                                        16m
+service-telemetry-operator-metrics                 ClusterIP   172.30.31.178    <none>        8383/TCP,8686/TCP                               16m
+smart-gateway-operator-metrics                     ClusterIP   172.30.249.39    <none>        8383/TCP,8686/TCP                               17m
 ----
 
 . Take note of the port and service name that you want to expose as a route, for example, service `prometheus-operated` and port `9090`.
@@ -49,11 +54,11 @@ route.route.openshift.io/metrics-store created
 [source,bash]
 ----
 $ oc get route metrics-store -ogo-template='{{.spec.host}}'
-metrics-store-service-telemetry.apps.infra.watch
+metrics-store-openstack-monitoring.apps.infra.watch
 ----
 
 +
-The `prometheus-operated` service is now available at the exposed DNS address, for example, https://metrics-store-service-telemetry.apps.infra.watch
+The `prometheus-operated` service is now available at the exposed DNS address, for example, https://metrics-store-openstack-monitoring.apps.infra.watch
 +
 [NOTE]
 The address of the route must be resolvable and configuration is environment specific.

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -15,7 +15,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec: {}
 EOF
 ----
@@ -29,7 +29,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   backends:
     events:

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
@@ -24,11 +24,11 @@ To deploy a custom Alertmanager route with {ProjectShort}, you must pass an `ale
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
 . Edit the `ServiceTelemetry` object for your {ProjectShort} deployment:
@@ -50,7 +50,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   backends:
     metrics:
@@ -61,7 +61,7 @@ spec:
     kind: Secret
     metadata:
       name: 'alertmanager-default'
-      namespace: 'service-telemetry'
+      namespace: 'openstack-monitoring'
     type: Opaque
     stringData:
       alertmanager.yaml: |-

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc
@@ -7,11 +7,11 @@ Prometheus evaluates alert rules to trigger notifications. If the rule condition
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
 . Create a `PrometheusRule` object that contains the alert rule. The Prometheus Operator loads the rule into Prometheus:
@@ -27,7 +27,7 @@ metadata:
     prometheus: default
     role: alert-rules
   name: prometheus-alarm-rules
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   groups:
     - name: ./openstack.rules
@@ -50,7 +50,7 @@ $ oc run curl --generator=run-pod/v1 --image=radial/busyboxplus:curl -i --tty
 [source,bash,options="nowrap"]
 ----
 [ root@curl:/ ]$ curl prometheus-operated:9090/api/v1/rules
-{"status":"success","data":{"groups":[{"name":"./openstack.rules","file":"/etc/prometheus/rules/prometheus-default-rulefiles-0/service-telemetry-prometheus-alarm-rules.yaml","rules":[{"name":"Metric Listener down","query":"collectd_qpid_router_status \u003c 1","duration":0,"labels":{},"annotations":{},"alerts":[],"health":"ok","type":"alerting"}],"interval":30}]}}
+{"status":"success","data":{"groups":[{"name":"./openstack.rules","file":"/etc/prometheus/rules/prometheus-default-rulefiles-0/openstack-monitoring-prometheus-alarm-rules.yaml","rules":[{"name":"Metric Listener down","query":"collectd_qpid_router_status \u003c 1","duration":0,"labels":{},"annotations":{},"alerts":[],"health":"ok","type":"alerting"}],"interval":30}]}}
 ----
 
 . To verify that the output shows the rules loaded into the `PrometheusRule` object, for example the output contains the defined `./openstack.rules`, exit the pod:

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -64,7 +64,7 @@ resource_registry:
 
 parameter_defaults:
     MetricsQdrConnectors:
-        - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch   # <2>
+        - host: stf-default-interconnect-5671-openstack-monitoring.apps.infra.watch   # <2>
           port: 443
           role: edge
           verifyHostname: false

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -31,11 +31,11 @@ endif::include_when_16[]
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
 . Edit the `default` ServiceTelemetry object and add a `clouds` parameter with your configuration:

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -2,17 +2,17 @@
 = Deploying {Project} to the {OpenShift} environment
 
 [role="_abstract"]
-Deploy {Project} ({ProjectShort}) to collect, store, and monitor events:
-
-
+Deploy {Project} ({ProjectShort}) to collect, store, and monitor events. The default namespace used throughout the documentation is `openstack-monitoring`, but can be substituted for any namespace you choose.
 
 .Procedure
 
-. Create a namespace to contain the {ProjectShort} components, for example, `service-telemetry`:
+. Create a namespace to contain the {ProjectShort} components, for example, `openstack-monitoring`:
++
+NOTE: In {ProjectShort} v1.3 and earlier the default namespace `service-telemetry` changed to `openstack-monitoring`, but {ProjectShort} can be deployed to any namespace you choose.
 +
 [source,bash,options="nowrap",role="white-space-pre"]
 ----
-$ oc new-project service-telemetry
+$ oc new-project openstack-monitoring
 ----
 . Create an OperatorGroup in the namespace so that you can schedule the Operator pods:
 +
@@ -23,10 +23,10 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: service-telemetry-operator-group
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   targetNamespaces:
-  - service-telemetry
+  - openstack-monitoring
 EOF
 ----
 +
@@ -100,7 +100,7 @@ EOF
 . Subscribe to the AMQ Certificate Manager Operator by using the redhat-operators CatalogSource:
 +
 [NOTE]
-The AMQ Certificate Manager deploys to the `openshift-operators` namespace and is then available to all namespaces across the cluster. As a result, on clusters with a large number of namespaces, it can take several minutes for the Operator to be available in the `service-telemetry` namespace. The AMQ Certificate Manager Operator is not compatible with the dependency management of Operator Lifecycle Manager when you use it with other namespace-scoped operators.
+The AMQ Certificate Manager deploys to the `openshift-operators` namespace and is then available to all namespaces across the cluster. As a result, on clusters with a large number of namespaces, it can take several minutes for the Operator to be available in the namespace. The AMQ Certificate Manager Operator is not compatible with the dependency management of Operator Lifecycle Manager when you use it with other namespace-scoped operators.
 +
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----
@@ -138,7 +138,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: elasticsearch-eck-operator-certified
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   channel: stable
   installPlanApproval: Automatic
@@ -169,7 +169,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: service-telemetry-operator
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   channel: stable-1.3
   installPlanApproval: Automatic
@@ -183,7 +183,7 @@ EOF
 +
 [source,bash,options="nowrap",role="white-space-pre"]
 ----
-$ oc get csv --namespace service-telemetry
+$ oc get csv --namespace openstack-monitoring
 
 amq7-cert-manager.v1.0.1                      Red Hat Integration - AMQ Certificate Manager   1.0.1                                                          Succeeded
 amq7-interconnect-operator.v1.10.1            Red Hat Integration - AMQ Interconnect          1.10.1           amq7-interconnect-operator.v1.2.4             Succeeded

--- a/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
@@ -9,11 +9,11 @@ You can adjust {Project} ({ProjectShort}) for additional metrics retention time.
 
 . Log in to {OpenShift}.
 
-. Change to the service-telemetry namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash,options="nowrap",role="white-space-pre"]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
 . Edit the ServiceTelemetry object:
@@ -34,7 +34,7 @@ apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
   name: stf-default
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   ...
   backends:

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -71,7 +71,7 @@ virtual-machine-view-1.3     2m
 ----
 $ oc get route grafana-route -ojsonpath='{.spec.host}'
 
-grafana-route-service-telemetry.apps.infra.watch
+grafana-route-openstack-monitoring.apps.infra.watch
 ----
 
 . In a web browser, navigate to https://_<grafana_route_address>_. Replace _<grafana_route_address>_ with the value that you retrieved in the previous step.

--- a/doc-Service-Telemetry-Framework/modules/proc_overriding-a-managed-manifest.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_overriding-a-managed-manifest.adoc
@@ -18,11 +18,11 @@ The `oc edit` command loads the default system editor. To override the default e
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
 . Load the `ServiceTelemetry` object into an editor:
@@ -51,7 +51,7 @@ spec:
     kind: Secret
     metadata:
       name: 'alertmanager-default'
-      namespace: 'service-telemetry'
+      namespace: 'openstack-monitoring'
     type: Opaque
     stringData:
       alertmanager.yaml: |-

--- a/doc-Service-Telemetry-Framework/modules/proc_removing-stf-from-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_removing-stf-from-the-openshift-environment.adoc
@@ -42,7 +42,7 @@ To remove the operational resources for {ProjectShort} from {OpenShift}, delete 
 +
 [source,bash]
 ----
-$ oc delete project service-telemetry
+$ oc delete project openstack-monitoring
 ----
 
 . Verify that the resources have been deleted from the namespace:

--- a/doc-Service-Telemetry-Framework/modules/proc_retrieving-and-setting-grafana-login-credentials.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_retrieving-and-setting-grafana-login-credentials.adoc
@@ -7,11 +7,11 @@
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 . To retrieve the default username and password, describe the Grafana object:
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_retrieving-the-qdr-route-address.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_retrieving-the-qdr-route-address.adoc
@@ -8,10 +8,17 @@ When you configure the {OpenStack} ({OpenStackShort}) overcloud for {Project} ({
 
 . Log in to your {OpenShift} environment.
 
-. In the `service-telemetry` project, retrieve the {MessageBus} route address:
+. Change to the `openstack-monitoring` namespace:
++
+[source,bash]
+----
+$ oc project openstack-monitoring
+----
+
+. In the namespace, retrieve the {MessageBus} route address:
 +
 [source,bash,options="nowrap",subs="verbatim"]
 ----
 $ oc get routes -ogo-template='{{ range .items }}{{printf "%s\n" .spec.host }}{{ end }}' | grep "\-5671"
-default-interconnect-5671-service-telemetry.apps.infra.watch
+default-interconnect-5671-openstack-monitoring.apps.infra.watch
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -9,11 +9,11 @@ ifdef::include_16[The dashboards in {ProjectShort} require features that are ava
 .Procedure
 
 . Log in to {OpenShift}.
-. Change to the `service-telemetry` namespace:
+. Change to the `openstack-monitoring` namespace:
 +
 [source,bash]
 ----
-$ oc project service-telemetry
+$ oc project openstack-monitoring
 ----
 
 . Deploy the Grafana operator:
@@ -25,7 +25,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: grafana-operator
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   channel: alpha
   installPlanApproval: Automatic
@@ -39,7 +39,7 @@ EOF
 +
 [source,bash,options="nowrap"]
 ----
-$ oc get csv --selector operators.coreos.com/grafana-operator.service-telemetry
+$ oc get csv --selector operators.coreos.com/grafana-operator.openstack-monitoring
 
 NAME                       DISPLAY            VERSION   REPLACES                   PHASE
 grafana-operator.v3.10.3   Grafana Operator   3.10.3    grafana-operator.v3.10.2   Succeeded
@@ -88,6 +88,6 @@ default-datasources     20h
 ----
 $ oc get route grafana-route
 
-NAME            HOST/PORT                                          PATH   SERVICES          PORT   TERMINATION   WILDCARD
-grafana-route   grafana-route-service-telemetry.apps.infra.watch          grafana-service   3000   edge          None
+NAME            HOST/PORT                                             PATH   SERVICES          PORT   TERMINATION   WILDCARD
+grafana-route   grafana-route-openstack-monitoring.apps.infra.watch          grafana-service   3000   edge          None
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-service-telemetry-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_subscribing-to-the-service-telemetry-operator.adoc
@@ -38,7 +38,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: service-telemetry-operator
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   channel: stable-1.3
   installPlanApproval: Automatic
@@ -56,7 +56,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: service-telemetry-operator
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   channel: stable-1.3
   installPlanApproval: Automatic
@@ -72,7 +72,7 @@ endif::[]
 +
 [source,bash,options="nowrap"]
 ----
-$ oc get csv --namespace service-telemetry
+$ oc get csv --namespace openstack-monitoring
 
 NAME                                         DISPLAY                                         VERSION          REPLACES                            PHASE
 amq7-cert-manager.v1.0.0                     Red Hat Integration - AMQ Certificate Manager   1.0.0                                                Succeeded

--- a/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
@@ -40,12 +40,12 @@ listener {
 $ sudo {containerbin} exec -it metrics_qdr qdstat --bus=172.17.1.44:5666 --connections
 
 Connections
-  id   host                                                                  container                                                                                                  role    dir  security                            authentication  tenant
-  ============================================================================================================================================================================================================================================================================================
-  1    default-interconnect-5671-service-telemetry.apps.infra.watch:443      default-interconnect-7458fd4d69-bgzfb                                                                      edge    out  TLSv1.2(DHE-RSA-AES256-GCM-SHA384)  anonymous-user
-  12   172.17.1.44:60290                                                     openstack.org/om/container/controller-0/ceilometer-agent-notification/25/5c02cee550f143ec9ea030db5cccba14  normal  in   no-security                         no-auth
-  16   172.17.1.44:36408                                                     metrics                                                                                                    normal  in   no-security                         anonymous-user
-  899  172.17.1.44:39500                                                     10a2e99d-1b8a-4329-b48c-4335e5f75c84                                                                       normal  in   no-security                         no-auth
+  id   host                                                                     container                                                                                                  role    dir  security                            authentication  tenant
+  ===============================================================================================================================================================================================================================================================================================
+  1    default-interconnect-5671-openstack-monitoring.apps.infra.watch:443      default-interconnect-7458fd4d69-bgzfb                                                                      edge    out  TLSv1.2(DHE-RSA-AES256-GCM-SHA384)  anonymous-user
+  12   172.17.1.44:60290                                                        openstack.org/om/container/controller-0/ceilometer-agent-notification/25/5c02cee550f143ec9ea030db5cccba14  normal  in   no-security                         no-auth
+  16   172.17.1.44:36408                                                        metrics                                                                                                    normal  in   no-security                         anonymous-user
+  899  172.17.1.44:39500                                                        10a2e99d-1b8a-4329-b48c-4335e5f75c84                                                                       normal  in   no-security                         no-auth
 ----
 +
 There are four connections:


### PR DESCRIPTION
Migrate to using openstack-monitoring as the default namespace. The
namespace service-telemetry doesn't mean a lot at first glance. The use
of openstack-monitoring makes it more clear the purpose of the
components in the namespace.

Closes: rhbz#2021646:
