### PR TITLE
Removed --generator=run-pod/v1 from 2 locations (#349)

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
@@ -99,7 +99,7 @@ receivers:
 +
 [source,bash]
 ----
-$ oc run curl --generator=run-pod/v1 --image=radial/busyboxplus:curl -i --tty
+$ oc run curl --image=radial/busyboxplus:curl -i --tty
 ----
 
 . Run `curl` against the `alertmanager-operated` service to retrieve the status and `configYAML` contents, and verify that the supplied configuration matches the configuration in Alertmanager:

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc
@@ -42,7 +42,7 @@ EOF
 +
 [source,bash]
 ----
-$ oc run curl --generator=run-pod/v1 --image=radial/busyboxplus:curl -i --tty
+$ oc run curl --image=radial/busyboxplus:curl -i --tty
 ----
 
 . Run the `curl` command to access the `prometheus-operated` service to return the rules loaded into memory:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2011145

Cherry picked from commit 9c24d0cd107ee9492801ffe1879f5b330a00f751
