### PR TITLE
Use built in base64 decode method

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc
@@ -42,7 +42,7 @@ EOF
 +
 [source,bash,options="nowrap"]
 ----
-$ curl -k --user "internal:$(oc get secret default-prometheus-htpasswd -ogo-template='{{ .data.password }}' | base64 -d)" https://$(oc get route default-prometheus-proxy -ogo-template='{{ .spec.host }}')/api/v1/rules
+$ curl -k --user "internal:$(oc get secret default-prometheus-htpasswd -ogo-template='{{ .data.password | base64decode }}')" https://$(oc get route default-prometheus-proxy -ogo-template='{{ .spec.host }}')/api/v1/rules
 
 {"status":"success","data":{"groups":[{"name":"./openstack.rules","file":"/etc/prometheus/rules/prometheus-default-rulefiles-0/service-telemetry-prometheus-alarm-rules.yaml","rules":[{"state":"inactive","name":"Collectd metrics receive count is zero","query":"rate(sg_total_collectd_msg_received_count[1m]) == 0","duration":0,"labels":{},"annotations":{},"alerts":[],"health":"ok","evaluationTime":0.00034627,"lastEvaluation":"2021-12-07T17:23:22.160448028Z","type":"alerting"}],"interval":30,"evaluationTime":0.000353787,"lastEvaluation":"2021-12-07T17:23:22.160444017Z"}]}}
 ----


### PR DESCRIPTION
Use the built in base64 decode method in the go-template rather than
piping contents into an external application
