### PR TITLE
Add note about alertmanager config encoding (#345)

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
@@ -38,6 +38,7 @@ include::../modules/con_alerts.adoc[leveloffset=+1]
 include::../modules/proc_creating-an-alert-rule-in-prometheus.adoc[leveloffset=+2]
 include::../modules/proc_configuring-custom-alerts.adoc[leveloffset=+2]
 include::../modules/proc_creating-an-alert-route-in-alertmanager.adoc[leveloffset=+2]
+include::../modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc[leveloffset=+2]
 
 //SNMP Traps
 include::../modules/proc_configuring-snmp-traps.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/modules/con_alerts.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_alerts.adoc
@@ -31,7 +31,9 @@ You create alert rules in Prometheus and alert routes in Alertmanager. Alert rul
 To create an alert, complete the following tasks:
 
 . Create an alert rule in Prometheus. For more information, see xref:creating-an-alert-rule-in-prometheus_assembly-advanced-features[].
-. Create an alert route in Alertmanager. For more information, see xref:creating-an-alert-route-in-alertmanager_assembly-advanced-features[].
+. Create an alert route in Alertmanager. There are two ways in which you can create an alert route:
+** xref:creating-an-alert-route-in-alertmanager_assembly-advanced-features[Creating a standard alert route in Alertmanager].
+** xref:proc_creating-an-alert-route-with-templating-in-alertmanager_assembly-advanced-features[Creating an alert route with templating in Alertmanager].
 
 
 .Additional resources

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-common-intro.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-common-intro.adoc
@@ -1,0 +1,17 @@
+[role="_abstract"]
+Use Alertmanager to deliver alerts to an external system, such as email, IRC, or other notification channel. The Prometheus Operator manages the Alertmanager configuration as a {OpenShift} secret. By default, {Project} ({ProjectShort}) deploys a basic configuration that results in no receivers:
+
+[source,yaml]
+----
+alertmanager.yaml: |-
+  global:
+    resolve_timeout: 5m
+  route:
+    group_by: ['job']
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 12h
+    receiver: 'null'
+  receivers:
+  - name: 'null'
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-common-procedure.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-common-procedure.adoc
@@ -1,0 +1,38 @@
+. To verify the configuration is loaded into Alertmanager, create a pod with access to `curl`:
++
+[source,bash]
+----
+$ oc run curl --image=radial/busyboxplus:curl -i --tty
+----
+
+
+. Run the `curl` command against the `alertmanager-operated` service to retrieve the status and `configYAML` contents, and verify that the supplied configuration matches the configuration in Alertmanager:
++
+[source,bash,options="nowrap"]
+----
+[ root@curl:/ ]$ curl alertmanager-operated:9093/api/v1/status
+
+{"status":"success","data":{"configYAML":"...",...}}
+----
+
+. Verify that the `configYAML` field contains the changes you expect.
+
+. Exit the pod:
++
+[source,bash]
+----
+[ root@curl:/ ]$ exit
+----
+
+. To clean up the environment, delete the `curl` pod:
++
+[source,bash]
+----
+$ oc delete pod curl
+
+pod "curl" deleted
+----
+
+.Additional resources
+
+* For more information about the {OpenShift} secret and the Prometheus operator, see https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md[Prometheus user guide on alerting].

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
@@ -1,5 +1,6 @@
-[id="creating-an-alert-route-in-alertmanager_{context}"]
-= Creating an alert route in Alertmanager
+
+[id="proc_creating-an-alert-route-with-templating-in-alertmanager_{context}"]
+= Creating an alert route with templating in Alertmanager
 
 // The introduction to the files proc_creating-an-alert-route-with-templating-in-alertmanager and creating-an-alert-route-in-alertmanager are identical. If you have changes to make, please make the same changes to both introductions.
 
@@ -21,13 +22,11 @@ alertmanager.yaml: |-
   - name: 'null'
 ----
 
-To deploy a custom Alertmanager route with {ProjectShort}, you must pass an `alertmanagerConfigManifest` parameter to the Service Telemetry Operator that results in an updated secret, managed by the Prometheus Operator.
-
-If your `alertmanagerConfigManifest` contains a custom template to construct the title and text of the sent alert, deploy the contents of the `alertmanagerConfigManifest` using a base64-encoded configuration. For more information, see xref:proc_creating-an-alert-route-with-templating-in-alertmanager_assembly-advanced-features[].
+If the `alertmanagerConfigManifest` parameter contains a custom template, for example, to construct the title and text of the sent alert, deploy the contents of the `alertmanagerConfigManifest` by using a base64-encoded configuration.
 
 .Procedure
 
-// The following steps are duplicated in proc_creating-an-alert-route-with-templating-in-alertmanager. If you have changes to make, please make the same changes to both files.
+// The following steps are duplicated in creating-an-alert-route-in-alertmanager. If you have changes to make, please make the same changes to both files.
 
 . Log in to {OpenShift}.
 . Change to the `service-telemetry` namespace:
@@ -44,10 +43,7 @@ $ oc project service-telemetry
 $ oc edit stf default
 ----
 
-. Add the new parameter `alertmanagerConfigManifest` and the `Secret` object contents to define the `alertmanager.yaml` configuration for Alertmanager:
-+
-[NOTE]
-This step loads the default template that the Service Telemetry Operator manages. To verify that the changes are populating correctly, change a value, return the `alertmanager-default` secret, and verify that the new value is loaded into memory. For example, change the value of the parameter `global.resolve_timeout` from `5m` to `10m`.
+. To deploy a custom Alertmanager route with {ProjectShort}, you must pass an `alertmanagerConfigManifest` parameter to the Service Telemetry Operator that results in an updated secret that is managed by the Prometheus Operator:
 +
 [source,yaml,options="nowrap"]
 ----
@@ -68,18 +64,8 @@ spec:
       name: 'alertmanager-default'
       namespace: 'service-telemetry'
     type: Opaque
-    stringData:
-      alertmanager.yaml: |-
-        global:
-          resolve_timeout: 10m
-        route:
-          group_by: ['job']
-          group_wait: 30s
-          group_interval: 5m
-          repeat_interval: 12h
-          receiver: 'null'
-        receivers:
-        - name: 'null'
+    data:
+      alertmanager.yaml: Z2xvYmFsOgogIHJlc29sdmVfdGltZW91dDogMTBtCiAgc2xhY2tfYXBpX3VybDogPHNsYWNrX2FwaV91cmw+CnJlY2VpdmVyczoKICAtIG5hbWU6IHNsYWNrCiAgICBzbGFja19jb25maWdzOgogICAgLSBjaGFubmVsOiAjc3RmLWFsZXJ0cwogICAgICB0aXRsZTogfC0KICAgICAgICAuLi4KICAgICAgdGV4dDogPi0KICAgICAgICAuLi4Kcm91dGU6CiAgZ3JvdXBfYnk6IFsnam9iJ10KICBncm91cF93YWl0OiAzMHMKICBncm91cF9pbnRlcnZhbDogNW0KICByZXBlYXRfaW50ZXJ2YWw6IDEyaAogIHJlY2VpdmVyOiAnc2xhY2snCg==
 ----
 
 . Verify that the configuration has been applied to the secret:
@@ -90,22 +76,30 @@ $ oc get secret alertmanager-default -o go-template='{{index .data "alertmanager
 
 global:
   resolve_timeout: 10m
+  slack_api_url: <slack_api_url>
+receivers:
+  - name: slack
+    slack_configs:
+    - channel: #stf-alerts
+      title: |-
+        ...
+      text: >-
+        ...
 route:
   group_by: ['job']
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h
-  receiver: 'null'
-receivers:
-- name: 'null'
+  receiver: 'slack'
 ----
 
-. To verify the configuration is loaded into Alertmanager, create a pod with access to `curl`:
+. To verify that the configuration loaded into Alertmanager, create a pod with access to the `curl` command:
 +
 [source,bash]
 ----
 $ oc run curl --image=radial/busyboxplus:curl -i --tty
 ----
+
 
 . Run the `curl` command against the `alertmanager-operated` service to retrieve the status and `configYAML` contents, and verify that the supplied configuration matches the configuration in Alertmanager:
 +


### PR DESCRIPTION
* Add note about alertmanager config encoding

Add a node and example about how to deal with complicated
alertmanager.yaml configurations. Suggests encoding the
alertmanager.yaml configuration as base64 and using the data definition
method in the Secret rather than stringData and defining the
configuration in plaintext.

Related: rhbz#2023763
Signed-off-by: Leif Madsen <lmadsen@redhat.com>

* Fix typo and syntax

* Changes to creating route in Alertmanager (#346)

* Created new file and made some basic changes to facilitate Leif's changes to the new "Creating alert route in AM" proc

* Additional Subs for disconnected support (#348)

* Additional Subs for disconnected support

* Removed --generator=run-pod/v1 from 2 locations (#349)

https://bugzilla.redhat.com/show_bug.cgi?id=2011145

* Fix up PrometheusRules validation (#351)

* Fix up PrometheusRules validation

Fix up the PrometheusRules validation to use basic authentication no
that oauth-proxy has been enabled by default. Also drop the use of an
in-cluster pod for running curl in favour of running curl locally from
the administration machine.

* Clean up output

* Update doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

* Minor syntax fix

* Reduce duplication across files

* Use built in base64 decode method (#352)

Use the built in base64 decode method in the go-template rather than
piping contents into an external application

* Add more practical example for base64 ended alertmanager configs

* Update doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc

Co-authored-by: Chris Sibbitt <csibbitt@redhat.com>
Co-authored-by: Leif Madsen <lmadsen@redhat.com>

* Final adjustments and de-duplication

* Rename concept module to proc intro common

* Removed content reuse from 2 files (#359)

* Removed content use from 2 files

* Update doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc

* Add notes about duplicated sections

Add some hints in the documentation as a comment in case others come
along and make changes to these files. It's not possible due to style
guide rules to include partial procedure sections, so the contents needs
to be duplicated. In order to keep data from becoming out of sync the
notes are being added with points on where to make changes across both
files.

* Update doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc

* Update doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-common-procedure.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>
Co-authored-by: Chris Sibbitt <csibbitt@redhat.com>

Cherry picked from commit aa60097dc58ccc27bce057283d697ec477c28338
