### PR TITLE
Adjust overcloud configuration to match multi-cloud

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -11,13 +11,14 @@ ifdef::include_when_13[]
 endif::include_when_13[]
 * Retrieve the {MessageBus} route address. For more information, see xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
 
+// The following configuration should match the contents in modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc. If you have changes to make, please make the same changes to both files.
 .Procedure
 
 . Log in to the {OpenStackShort} undercloud as the `stack` user.
 
 . Create a configuration file called `stf-connectors.yaml` in the `/home/stack` directory.
 
-. In the `stf-connectors.yaml` file, configure the `MetricsQdrConnectors` address to connect the {MessageBus} on the overcloud to the {ProjectShort} deployment.
+. In the `stf-connectors.yaml` file, configure the `MetricsQdrConnectors` address to connect the {MessageBus} on the overcloud to the {ProjectShort} deployment. The topic addresses for Sensubility, Ceilometer, and collectd are configured here to match the defaults in {ProjectShort}. For more information about customizing topics and cloud configuration, see xref:configuring-multiple-clouds_assembly-completing-the-stf-configuration[].
 
 * Replace the `host` parameter with the value of `HOST/PORT` that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
 
@@ -27,20 +28,53 @@ endif::include_when_13[]
 +
 [source,yaml,options="nowrap"]
 ----
+resource_registry:
+  OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml    # <1>
+
 parameter_defaults:
     MetricsQdrConnectors:
-    - host: default-interconnect-5671-service-telemetry.apps.infra.watch
-      port: 443
-      role: edge
-      sslProfile: sslProfile
-      verifyHostname: false
+        - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch   # <2>
+          port: 443
+          role: edge
+          verifyHostname: false
+          sslProfile: sslProfile
 
     MetricsQdrSSLProfiles:
-    -   name: sslProfile
+        - name: sslProfile
 ifdef::include_when_13[]
-        caCertFileContent: |
-          ----BEGIN CERTIFICATE----
-          <snip>
-          ----END CERTIFICATE----
+          caCertFileContent: |
+            ----BEGIN CERTIFICATE----
+            <snip>
+            ----END CERTIFICATE----
 endif::include_when_13[]
+
+    CeilometerQdrEventsConfig:
+        driver: amqp
+        topic: cloud1-event   # <3>
+
+    CeilometerQdrMetricsConfig:
+        driver: amqp
+        topic: cloud1-metering   # <4>
+
+    CollectdAmqpInstances:
+        cloud1-notify:        # <5>
+            notify: true
+            format: JSON
+            presettle: false
+        cloud1-telemetry:     # <6>
+            format: JSON
+            presettle: false
+
+ifdef::include_when_16[]
+    CollectdSensubilityResultsChannel: sensubility/cloud1-telemetry # <7>
+endif::include_when_16[]
 ----
+<1> Directly load the collectd service because you are not including the `collectd-write-qdr.yaml` environment file for multiple cloud deployments.
+<2> Replace the `host` parameter with the value of `HOST/PORT` that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
+<3> Define the topic for Ceilometer events. This value is the address format of `anycast/ceilometer/cloud1-event.sample`.
+<4> Define the topic for Ceilometer metrics. This value is the address format of `anycast/ceilometer/cloud1-metering.sample`.
+<5> Define the topic for collectd events. This value is the format of `collectd/cloud1-notify`.
+<6> Define the topic for collectd metrics. This value is the format of `collectd/cloud1-telemetry`.
+ifdef::include_when_16[]
+<7> Define the topic for collectd-sensubility events. Ensure that this value is the exact string format `sensubility/cloud1-telemetry`
+endif::include_when_16[]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -56,6 +56,8 @@ ifdef::include_when_13[]
 * Replace the `caCertFileContent` parameter with the contents retrieved in xref:getting-ca-certificate-from-stf-for-overcloud-configuration_assembly-completing-the-stf-configuration[].
 +
 endif::include_when_13[]
+// The following configuration should match the contents in modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc. If you have changes to make, please make the same changes to both files.
++
 .stf-connectors.yaml
 [source,yaml,options="nowrap"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -111,7 +111,6 @@ parameter_defaults:
     # enable collection of API status
     CollectdEnableSensubility: true
     CollectdSensubilityTransport: amqp1
-    CollectdSensubilityResultsChannel: sensubility/telemetry
 
     # enable collection of containerized service metrics
     CollectdEnableLibpodstats: true

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud.adoc
@@ -19,7 +19,6 @@ Deploy or update the overcloud with the required environment files so that data 
 
 . Add the following files to your {OpenStackShort} {OpenStackInstaller} deployment to configure data collection and {MessageBus}:
 +
-* The `collectd-write-qdr.yaml` file to ensure that collectd telemetry and events are sent to {ProjectShort}
 * The `ceilometer-write-qdr.yaml` file to ensure that Ceilometer telemetry and events are sent to {ProjectShort}
 * The `qdr-edge-only.yaml` file to ensure that the message bus is enabled and connected to {ProjectShort} message bus routers
 * The `enable-stf.yaml` environment file to ensure defaults are configured correctly
@@ -31,11 +30,10 @@ Deploy or update the overcloud with the required environment files so that data 
 +
 [source,bash,options="nowrap",subs="+quotes"]
 ----
-(undercloud) [stack@undercloud-0 ~]$ openstack overcloud deploy _<other_arguments>_
+(undercloud) [stack@undercloud-0 ~]$ openstack overcloud deploy _<other_arguments>_ 
 --templates /usr/share/openstack-tripleo-heat-templates \
   --environment-file _<...other_environment_files...>_ \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
-  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-write-qdr.yaml \
   --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml \
   --environment-file /home/stack/enable-stf.yaml \
   --environment-file /home/stack/stf-connectors.yaml


### PR DESCRIPTION
Adjust the standard installation to match the multi-cloud configuration
since Service Telemetry Operator is now aligned to using a 'cloud1-...'
prefix by default.
