### PR TITLE
Update df example to be correct

### DIFF
--- a/common/collectd/ref_collectd-plugins.adoc
+++ b/common/collectd/ref_collectd-plugins.adoc
@@ -470,7 +470,7 @@ parameter_defaults:
     CollectdExtraPlugins:
       - df
     ExtraConfig:
-        collectd::plugin::df::FStype: "ext4"
+        collectd::plugin::df::fstypes: ['tmpfs','xfs']
 ----
 
 .Additional resources


### PR DESCRIPTION
The df plugin example for collectd is invalid. This change updates the
example to use the proper values and shows how to provide a list vs
single value.

Resolves: rhbz#2035329
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
