### PR TITLE
Update console output and add SGO sub step

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -125,8 +125,8 @@ EOF
 ----
 $ oc get --namespace openshift-operators csv
 
-NAME                       DISPLAY                                         VERSION   REPLACES   PHASE
-amq7-cert-manager.v1.0.1   Red Hat Integration - AMQ Certificate Manager   1.0.1                Succeeded
+NAME                       DISPLAY                                         VERSION   REPLACES                   PHASE
+amq7-cert-manager.v1.0.3   Red Hat Integration - AMQ Certificate Manager   1.0.3     amq7-cert-manager.v1.0.2   Succeeded
 ----
 
 . If you plan to store events in ElasticSearch, you must enable the Elastic Cloud on Kubernetes (ECK) Operator. To enable the ECK Operator, create the following manifest in your {OpenShift} environment:
@@ -156,8 +156,27 @@ $ oc get csv
 
 NAME                                          DISPLAY                        VERSION   REPLACES                                     PHASE
 ...
-elasticsearch-eck-operator-certified.v1.8.0   Elasticsearch (ECK) Operator   1.8.0     elasticsearch-eck-operator-certified.v1.7.1  Succeeded
+elasticsearch-eck-operator-certified.1.9.1   Elasticsearch (ECK) Operator                    1.9.1                                Succeeded
 ...
+----
+
+. Create the Smart Gateway Operator subscription to manage the Smart Gateway instances:
++
+[source,yaml,options="nowrap",role="white-space-pre"]
+----
+$ oc create -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: smart-gateway-operator
+  namespace: service-telemetry
+spec:
+  channel: stable-1.3
+  installPlanApproval: Automatic
+  name: smart-gateway-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
 ----
 
 . Create the Service Telemetry Operator subscription to manage the {ProjectShort} instances:
@@ -185,10 +204,11 @@ EOF
 ----
 $ oc get csv --namespace service-telemetry
 
-amq7-cert-manager.v1.0.1                      Red Hat Integration - AMQ Certificate Manager   1.0.1                                                          Succeeded
-amq7-interconnect-operator.v1.10.1            Red Hat Integration - AMQ Interconnect          1.10.1           amq7-interconnect-operator.v1.2.4             Succeeded
-elasticsearch-eck-operator-certified.v1.8.0   Elasticsearch (ECK) Operator                    1.8.0            elasticsearch-eck-operator-certified.v1.7.1   Succeeded
-prometheusoperator.0.47.0                     Prometheus Operator                             0.47.0           prometheusoperator.0.37.0                     Succeeded
-service-telemetry-operator.v1.3.1632925572    Service Telemetry Operator                      1.3.1632925572                                                 Succeeded
-smart-gateway-operator.v3.0.1632925565        Smart Gateway Operator                          3.0.1632925565                                                 Succeeded
+NAME                                         DISPLAY                                         VERSION          REPLACES                             PHASE
+amq7-cert-manager.v1.0.3                     Red Hat Integration - AMQ Certificate Manager   1.0.3            amq7-cert-manager.v1.0.2             Succeeded
+amq7-interconnect-operator.v1.10.5           Red Hat Integration - AMQ Interconnect          1.10.5           amq7-interconnect-operator.v1.10.4   Succeeded
+elasticsearch-eck-operator-certified.1.9.1   Elasticsearch (ECK) Operator                    1.9.1                                                 Succeeded
+prometheusoperator.0.47.0                    Prometheus Operator                             0.47.0           prometheusoperator.0.37.0            Succeeded
+service-telemetry-operator.v1.3.1635451892   Service Telemetry Operator                      1.3.1635451892                                        Succeeded
+smart-gateway-operator.v3.0.1635451893       Smart Gateway Operator                          3.0.1635451893                                        Succeeded
 ----


### PR DESCRIPTION
Update the latest console output based on STF 1.3 installation
instructions.

Add explicit subscription step for Smart Gateway Operator to pull from
the stable-1.3 channel instead of relying on the defaultChannel in the
smart-gateway-operator package manifest, which after release of STF 1.4
is resulting in the deployment of the wrong CSV for Smart Gateway
Operator.

Resolves: rhbz#2046538
