### PR TITLE
Increase the send queue limit to avoid metrics (#383)

### DIFF
--- a/common/collectd/ref_collectd-plugins.adoc
+++ b/common/collectd/ref_collectd-plugins.adoc
@@ -204,6 +204,13 @@ Use the `amqp1` plugin to write values to an amqp1 message bus, for example, {Me
 |Integer
 |===
 
+Use the `send_queue_limit` parameter to limit the length of the outgoing metrics queue.
+
+[NOTE]
+If there is no AMQP1 connection, the plugin continues to queue messages to send, which can result in unbounded memory consumption. The default value is 0, which disables the outgoing metrics queue. 
+
+Increase the value of the `send_queue_limit` parameter if metrics are missing.
+
 .Example configuration:
 
 ----
@@ -211,7 +218,7 @@ Use the `amqp1` plugin to write values to an amqp1 message bus, for example, {Me
     CollectdExtraPlugins:
       - amqp1
     ExtraConfig:
-      collectd::plugin::amqp1::send_queue_limit: 50
+      collectd::plugin::amqp1::send_queue_limit: 5000
 ----
 
 [discrete]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -69,7 +69,8 @@ parameter_defaults:
         - volume.*
 
         # to avoid filling the memory buffers if disconnected from the message bus
-        collectd::plugin::amqp1::send_queue_limit: 50
+        # note: Adjust the value of the `send_queue_limit` to handle your required volume of metrics.
+        collectd::plugin::amqp1::send_queue_limit: 5000
 
         # receive extra information about virtual memory
         collectd::plugin::vmem::verbose: true
@@ -151,7 +152,8 @@ parameter_defaults:
         - volume.*
 
         # to avoid filling the memory buffers if disconnected from the message bus
-        collectd::plugin::amqp1::send_queue_limit: 50
+        # note: this may need an adjustment if there are many metrics to be sent.
+        collectd::plugin::amqp1::send_queue_limit: 5000
 
         # receive extra information about virtual memory
         collectd::plugin::vmem::verbose: true


### PR DESCRIPTION
* Increase the send queue limit to avoid metrics

being dropped too early.

* Update common/collectd/ref_collectd-plugins.adoc

Co-authored-by: igallagh-redhat <62542106+igallagh-redhat@users.noreply.github.com>

* Update common/collectd/ref_collectd-plugins.adoc

Co-authored-by: igallagh-redhat <62542106+igallagh-redhat@users.noreply.github.com>

* Update common/collectd/ref_collectd-plugins.adoc

Co-authored-by: igallagh-redhat <62542106+igallagh-redhat@users.noreply.github.com>

* Update doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc

Co-authored-by: igallagh-redhat <62542106+igallagh-redhat@users.noreply.github.com>

* Update common/collectd/ref_collectd-plugins.adoc

Co-authored-by: igallagh-redhat <62542106+igallagh-redhat@users.noreply.github.com>

* Fix linefeeds for NOTE box

Co-authored-by: igallagh-redhat <62542106+igallagh-redhat@users.noreply.github.com>
Co-authored-by: Leif Madsen <lmadsen@redhat.com>

Cherry picked from commit c8a315363898a4bb28904b894c17dfc271d10525
