### PR TITLE
Be implicit about OCP and CRC versions required

### DIFF
--- a/common/global/stf-attributes.adoc
+++ b/common/global/stf-attributes.adoc
@@ -35,6 +35,7 @@ ifeval::["{build}" == "upstream"]
 :MessageBus: Apache{nbsp}Qpid{nbsp}Dispatch{nbsp}Router
 :SupportedOpenShiftVersion: 4.10
 :NextSupportedOpenShiftVersion: 4.10
+:CodeReadyContainersVersion: 2.6.0
 endif::[]
 
 ifeval::["{build}" == "downstream"]

--- a/doc-Service-Telemetry-Framework/modules/con_development-environment-resource-requirements.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_development-environment-resource-requirements.adoc
@@ -30,6 +30,8 @@ ifeval::["{build}" == "upstream"]
 [role="_abstract"]
 You can create an all-in-one development environment for {ProjectShort} locally by using https://code-ready.github.io/crc/[CodeReady Containers]. The installation process of CodeReady Containers (CRC) is available at https://code-ready.github.io/crc/#installation_gsg.
 
+Deployment of {OpenShift} {SupportedOpenShiftVersion} is required for {ProjectShort}. The compatible version of CRC is {CodeReadyContainersVersion}, available at https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/{CodeReadyContainersVersion}/
+
 The https://code-ready.github.io/crc/#minimum-system-requirements-hardware_gsg[minimum resource requirements] for CRC is not enough by default to run {ProjectShort}. Ensure that your host system has the following resources available:
 
 * 4 physical cores (8 hyperthreaded cores)


### PR DESCRIPTION
Be implicit about the version of CRC and OCP required to result in a
development environment.
