### PR TITLE
PEM headers were incorrect, causing connection failures

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -44,9 +44,9 @@ parameter_defaults:
         - name: sslProfile
 ifdef::include_when_13,include_when_17[]
           caCertFileContent: |
-            ----BEGIN CERTIFICATE----
+            -----BEGIN CERTIFICATE-----
             <snip>
-            ----END CERTIFICATE----
+            -----END CERTIFICATE-----
 endif::include_when_13,include_when_17[]
 
     CeilometerQdrEventsConfig:

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -76,9 +76,9 @@ parameter_defaults:
         - name: sslProfile
 ifdef::include_when_13,include_when_17[]
           caCertFileContent: |
-            ----BEGIN CERTIFICATE----
+            -----BEGIN CERTIFICATE-----
             <snip>
-            ----END CERTIFICATE----
+            -----END CERTIFICATE-----
 endif::include_when_13,include_when_17[]
 
     CeilometerQdrEventsConfig:


### PR DESCRIPTION
* I had been in the habit of pasting the WHOLE cert, this time I pasted just the `<snip>` part and got this:

2022-10-21 13:32:12.054162 +0000 SERVER (error) SSL CA configuration failed for connection [C13577] to default-interconnect-5671-service-telemetry.... 
2022-10-21 13:32:12.055518 +0000 SERVER (error) [C13577] Connection aborted due to internal setup error

* https://www.rfc-editor.org/rfc/rfc7468#page-3
* Fixing these headers in my stf-connectors.yaml fixed my connections