### PR TITLE
Fix casing in use of Elasticsearch

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_high-availability.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_high-availability.adoc
@@ -10,7 +10,7 @@ With high availability, {Project} ({ProjectShort}) can rapidly recover from fail
 
 Enabling high availability has the following effects:
 
-* Three ElasticSearch pods run instead of the default one.
+* Three Elasticsearch pods run instead of the default one.
 * The following components run two pods instead of the default one:
 ** {MessageBus}
 ** Alertmanager

--- a/doc-Service-Telemetry-Framework/modules/con_network-considerations-for-service-telemetry-framework.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_network-considerations-for-service-telemetry-framework.adoc
@@ -3,4 +3,4 @@
 [id="con-network-considerations-for-service-telemetry-framework_{context}"]
 = Network considerations for Service Telemetry Framework
 
-You can only deploy {Project}({ProjectShort}) in a fully connected network environment. You cannot deploy {ProjectShort} in {OpenShift}-disconnected environments or network proxy environments.
+You can only deploy {Project} ({ProjectShort}) in a fully connected network environment. You cannot deploy {ProjectShort} in {OpenShift}-disconnected environments or network proxy environments.

--- a/doc-Service-Telemetry-Framework/modules/con_node-tuning-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_node-tuning-operator.adoc
@@ -49,6 +49,6 @@ When scheduling an Elasticsearch pod, there must be a label present that matches
 
 .Additional resources
 
-* For more information about virtual memory usage by Elasticsearch, see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
+* For more information about virtual memory use by Elasticsearch, see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
 
 * For more information about how the profiles are applied to nodes, see https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/scalability_and_performance/using-node-tuning-operator.html#custom-tuning-specification_node-tuning-operator[Custom tuning specification].

--- a/doc-Service-Telemetry-Framework/modules/con_node-tuning-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_node-tuning-operator.adoc
@@ -26,29 +26,29 @@
 = Node tuning operator
 
 [role="_abstract"]
-{ProjectShort} uses ElasticSearch to store events, which requires a larger than normal `vm.max_map_count`. The `vm.max_map_count` value is set by default in {OpenShift}.
+{ProjectShort} uses Elasticsearch to store events, which requires a larger than normal `vm.max_map_count`. The `vm.max_map_count` value is set by default in {OpenShift}.
 
 [TIP]
-If your host platform is a typical {OpenShift} 4 environment, do not make any adjustments. The default node tuning operator is configured to account for ElasticSearch workloads.
+If your host platform is a typical {OpenShift} 4 environment, do not make any adjustments. The default node tuning operator is configured to account for Elasticsearch workloads.
 
 If you want to edit the value of `vm.max_map_count`, you cannot apply node tuning manually using the `sysctl` command because {OpenShift} manages nodes directly. To configure values and apply them to the infrastructure, you must use the node tuning operator. For more information, see https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/scalability_and_performance/using-node-tuning-operator.html[Using the Node Tuning Operator].
 
-In an {OpenShiftShort} deployment, the default node tuning operator specification provides the required profiles for ElasticSearch workloads or pods scheduled on nodes. To view the default cluster node tuning specification, run the following command:
+In an {OpenShiftShort} deployment, the default node tuning operator specification provides the required profiles for Elasticsearch workloads or pods scheduled on nodes. To view the default cluster node tuning specification, run the following command:
 
 [source,bash]
 ----
 $ oc get Tuned/default -o yaml -n openshift-cluster-node-tuning-operator
 ----
 
-The output of the default specification is documented at https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/scalability_and_performance/using-node-tuning-operator.html#custom-tuning-default-profiles-set_node-tuning-operator[Default profiles set on a cluster]. You can manage the assignment of profiles in the `recommend` section where profiles are applied to a node when certain conditions are met. When scheduling ElasticSearch to a node in {ProjectShort}, one of the following profiles is applied:
+The output of the default specification is documented at https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/scalability_and_performance/using-node-tuning-operator.html#custom-tuning-default-profiles-set_node-tuning-operator[Default profiles set on a cluster]. You can manage the assignment of profiles in the `recommend` section where profiles are applied to a node when certain conditions are met. When scheduling Elasticsearch to a node in {ProjectShort}, one of the following profiles is applied:
 
 * `openshift-control-plane-es`
 * `openshift-node-es`
 
-When scheduling an ElasticSearch pod, there must be a label present that matches `tuned.openshift.io/elasticsearch`. If the label is present, one of the two profiles is assigned to the pod. No action is required by the administrator if you use the recommended Operator for ElasticSearch. If you use a custom-deployed ElasticSearch with {ProjectShort}, ensure that you add the `tuned.openshift.io/elasticsearch` label to all scheduled pods.
+When scheduling an Elasticsearch pod, there must be a label present that matches `tuned.openshift.io/elasticsearch`. If the label is present, one of the two profiles is assigned to the pod. No action is required by the administrator if you use the recommended Operator for Elasticsearch. If you use a custom-deployed Elasticsearch with {ProjectShort}, ensure that you add the `tuned.openshift.io/elasticsearch` label to all scheduled pods.
 
 .Additional resources
 
-* For more information about virtual memory usage by ElasticSearch, see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
+* For more information about virtual memory usage by Elasticsearch, see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
 
 * For more information about how the profiles are applied to nodes, see https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/scalability_and_performance/using-node-tuning-operator.html#custom-tuning-specification_node-tuning-operator[Custom tuning specification].

--- a/doc-Service-Telemetry-Framework/modules/con_persistent-volumes.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_persistent-volumes.adoc
@@ -2,7 +2,7 @@
 = Persistent volumes
 
 [role="_abstract"]
-{Project} ({ProjectShort}) uses persistent storage in {OpenShift} to request persistent volumes so that Prometheus and ElasticSearch can store metrics and events.
+{Project} ({ProjectShort}) uses persistent storage in {OpenShift} to request persistent volumes so that Prometheus and Elasticsearch can store metrics and events.
 
 When you enable persistent storage through the Service Telemetry Operator, the Persistent Volume Claims (PVC) requested in an {ProjectShort} deployment results in an access mode of RWO (ReadWriteOnce). If your environment contains pre-provisioned persistent volumes, ensure that volumes of RWO are available in the {OpenShift} default configured `storageClass`.
 
@@ -13,4 +13,4 @@ When you enable persistent storage through the Service Telemetry Operator, the P
 
 * For more information about configuring persistent storage for Prometheus in {ProjectShort}, see xref:backends-configuring-persistent-storage-for-prometheus_assembly-installing-the-core-components-of-stf[].
 
-* For more information about configuring persistent storage for ElasticSearch in {ProjectShort}, see xref:backends-configuring-persistent-storage-for-elasticsearch_assembly-installing-the-core-components-of-stf[].
+* For more information about configuring persistent storage for Elasticsearch in {ProjectShort}, see xref:backends-configuring-persistent-storage-for-elasticsearch_assembly-installing-the-core-components-of-stf[].

--- a/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
@@ -25,7 +25,7 @@ Support for `servicetelemetry.infra.watch/v1alpha1` was removed from {ProjectSho
 
 Use the `backends` parameter to control which storage back ends are available for storage of metrics and events, and to control the enablement of Smart Gateways that the `clouds` parameter defines. For more information, see xref:clouds_assembly-installing-the-core-components-of-stf[].
 
-Currently, you can use Prometheus as the metrics storage back end and ElasticSearch as the events storage back end.
+Currently, you can use Prometheus as the metrics storage back end and Elasticsearch as the events storage back end.
 
 [discrete]
 === Enabling Prometheus as a storage back end for metrics
@@ -95,9 +95,9 @@ spec:
 ----
 
 [discrete]
-=== Enabling ElasticSearch as a storage back end for events
+=== Enabling Elasticsearch as a storage back end for events
 
-To enable ElasticSearch as a storage back end for events, you must configure the `ServiceTelemetry` object.
+To enable Elasticsearch as a storage back end for events, you must configure the `ServiceTelemetry` object.
 
 .Procedure
 
@@ -119,9 +119,9 @@ spec:
 
 [id="backends-configuring-persistent-storage-for-elasticsearch_{context}"]
 [discrete]
-=== Configuring persistent storage for ElasticSearch
+=== Configuring persistent storage for Elasticsearch
 
-Use the additional parameters defined in `backends.events.elasticsearch.storage.persistent` to configure persistent storage options for ElasticSearch, such as storage class and volume size.
+Use the additional parameters defined in `backends.events.elasticsearch.storage.persistent` to configure persistent storage options for Elasticsearch, such as storage class and volume size.
 
 Use `storageClass` to define the back end storage class. If you do not set this parameter, the Service Telemetry Operator uses the default storage class for the {OpenShift} cluster.
 

--- a/doc-Service-Telemetry-Framework/modules/con_resource-allocation.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_resource-allocation.adoc
@@ -13,4 +13,4 @@ The amount of resources that you require to run {Project} ({ProjectShort}) depen
 
 * For recommendations about sizing for metrics collection, see https://access.redhat.com/articles/4907241[Service Telemetry Framework Performance and Scaling].
 
-* For information about sizing requirements for ElasticSearch, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html.
+* For information about sizing requirements for Elasticsearch, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html.

--- a/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
@@ -19,10 +19,10 @@
 ** Ceilometer: Collects {OpenStackShort} metrics and events.
 * Transport
 ** {MessageBus}: An AMQP 1.x compatible messaging bus that provides fast and reliable data transport to transfer the metrics to {ProjectShort} for storage.
-** Smart Gateway: A Golang application that takes metrics and events from the AMQP 1.x bus to deliver to ElasticSearch or Prometheus.
+** Smart Gateway: A Golang application that takes metrics and events from the AMQP 1.x bus to deliver to Elasticsearch or Prometheus.
 * Data storage
 ** Prometheus: Time-series data storage that stores {ProjectShort} metrics received from the Smart Gateway.
-** ElasticSearch: Events data storage that stores {ProjectShort} events received from the Smart Gateway.
+** Elasticsearch: Events data storage that stores {ProjectShort} events received from the Smart Gateway.
 * Observation
 ** Alertmanager: An alerting tool that uses Prometheus alert rules to manage alerts.
 ** Grafana: A visualization and analytics application that you can use to query, visualize, and explore data.
@@ -47,7 +47,7 @@ The following table describes the application of the client and server component
 |no
 |yes
 
-|ElasticSearch
+|Elasticsearch
 |no
 |yes
 
@@ -70,7 +70,7 @@ image::OpenStack_STF_Overview_37_1019_arch.png[Service Telemetry Framework archi
 
 For client side metrics, collectd provides infrastructure metrics without project data, and Ceilometer provides {OpenStackShort} platform data based on projects or user workload. Both Ceilometer and collectd deliver data to Prometheus by using the {MessageBus} transport, delivering the data through the message bus. On the server side, a Golang application called the Smart Gateway takes the data stream from the bus and exposes it as a local scrape endpoint for Prometheus.
 
-If you plan to collect and store events, collectd and Ceilometer deliver event data to the server side by using the {MessageBus} transport. Another Smart Gateway writes the data to the ElasticSearch datastore.
+If you plan to collect and store events, collectd and Ceilometer deliver event data to the server side by using the {MessageBus} transport. Another Smart Gateway writes the data to the Elasticsearch datastore.
 
 Server-side {ProjectShort} monitoring infrastructure consists of the following layers:
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-a-servicetelemetry-object-in-openshift.adoc
@@ -20,7 +20,7 @@ spec: {}
 EOF
 ----
 +
-To override a default value, define the parameter that you want to override. In this example, enable ElasticSearch by setting `enabled` to `true`:
+To override a default value, define the parameter that you want to override. In this example, enable Elasticsearch by setting `enabled` to `true`:
 +
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----
@@ -143,7 +143,7 @@ localhost                  : ok=90   changed=0    unreachable=0    failed=0    s
 
 * To determine that all workloads are operating correctly, view the pods and the status of each pod.
 +
-NOTE: If you set the `backends.events.elasticsearch.enabled` parameter to `true`, the notification Smart Gateways report `Error` and `CrashLoopBackOff` error messages for a period of time before ElasticSearch starts.
+NOTE: If you set the `backends.events.elasticsearch.enabled` parameter to `true`, the notification Smart Gateways report `Error` and `CrashLoopBackOff` error messages for a period of time before Elasticsearch starts.
 
 +
 [source,bash,options="nowrap"]

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -213,7 +213,7 @@ NAME                        DISPLAY               VERSION   REPLACES            
 prometheusoperator.0.47.0   Prometheus Operator   0.47.0    prometheusoperator.0.37.0   Succeeded
 ----
 
-. If you plan to store events in ElasticSearch, you must enable the Elastic Cloud on Kubernetes (ECK) Operator. To enable the ECK Operator, create the following manifest in your {OpenShift} environment:
+. If you plan to store events in Elasticsearch, you must enable the Elastic Cloud on Kubernetes (ECK) Operator. To enable the ECK Operator, create the following manifest in your {OpenShift} environment:
 +
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/ref_manifest-override-parameters.adoc
+++ b/doc-Service-Telemetry-Framework/modules/ref_manifest-override-parameters.adoc
@@ -36,7 +36,7 @@ This table describes the available parameters that you can use to override a man
 
 | `alertmanagerConfigManifest` | Override the `Secret` that contains the Alertmanager configuration. The Prometheus Operator uses a secret named `alertmanager-{{ alertmanager-name }}`, for example, `default`, to provide the `alertmanager.yaml` configuration to Alertmanager.  | `oc get secret alertmanager-default -oyaml`
 
-| `elasticsearchManifest` | Override the `ElasticSearch` object creation. The Elastic Cloud on Kuberneters Operator watches for `ElasticSearch` objects. | `oc get elasticsearch elasticsearch -oyaml`
+| `elasticsearchManifest` | Override the `Elasticsearch` object creation. The Elastic Cloud on Kuberneters Operator watches for `Elasticsearch` objects. | `oc get elasticsearch elasticsearch -oyaml`
 
 | `interconnectManifest` | Override the `Interconnect` object creation. The AMQ Interconnect Operator watches for `Interconnect` objects. | `oc get interconnect default-interconnect -oyaml`
 


### PR DESCRIPTION
Fix the casing in Elasticsearch from the invalid use of ElasticSearch.
Also fix one minor issue with a missing space.
