### PR TITLE
Remove use of OperatorHub.io for subscriptions

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -2,9 +2,7 @@
 = Deploying {Project} to the {OpenShift} environment
 
 [role="_abstract"]
-Deploy {Project} ({ProjectShort}) to collect, store, and monitor events:
-
-
+Deploy {Project} ({ProjectShort}) to collect and store telemetry from {OpenStack} ({OpenStackShort}).
 
 .Procedure
 
@@ -163,28 +161,11 @@ NAME                                 DISPLAY                                  VE
 amq7-interconnect-operator.v1.10.10  Red Hat Integration - AMQ Interconnect   1.10.10   amq7-interconnect-operator.v1.10.4   Succeeded
 ----
 
-. Enable the OperatorHub.io Community Catalog Source to install data storage and visualization Operators:
+
+. If you plan to store metrics in Prometheus, you must enable the Prometheus Operator. To enable the Prometheus Operator, create the following manifest in your {OpenShift} environment:
 +
 [WARNING]
 Red Hat supports the core Operators and workloads, including {MessageBus}, Service Telemetry Operator, and Smart Gateway Operator. Red Hat does not support the community Operators or workload components, inclusive of Elasticsearch, Prometheus, Alertmanager, Grafana, and their Operators.
-+
-[source,yaml,options="nowrap",role="white-space-pre"]
-----
-$ oc create -f - <<EOF
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: operatorhubio-operators
-  namespace: openshift-marketplace
-spec:
-  sourceType: grpc
-  image: quay.io/operatorhubio/catalog:latest
-  displayName: OperatorHub.io Operators
-  publisher: OperatorHub.io
-EOF
-----
-
-. If you plan to store metrics in Prometheus, you must enable the Prometheus Operator. To enable the Prometheus Operator, create the following manifest in your {OpenShift} environment:
 +
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----
@@ -198,7 +179,7 @@ spec:
   channel: beta
   installPlanApproval: Automatic
   name: prometheus
-  source: operatorhubio-operators
+  source: community-operators
   sourceNamespace: openshift-marketplace
 EOF
 ----
@@ -210,10 +191,13 @@ EOF
 $ oc get csv --selector=operators.coreos.com/prometheus.service-telemetry
 
 NAME                        DISPLAY               VERSION   REPLACES                    PHASE
-prometheusoperator.0.47.0   Prometheus Operator   0.47.0    prometheusoperator.0.37.0   Succeeded
+prometheusoperator.0.56.3   Prometheus Operator   0.56.3    prometheusoperator.0.47.0   Succeeded
 ----
 
 . If you plan to store events in Elasticsearch, you must enable the Elastic Cloud on Kubernetes (ECK) Operator. To enable the ECK Operator, create the following manifest in your {OpenShift} environment:
++
+[WARNING]
+Red Hat supports the core Operators and workloads, including {MessageBus}, Service Telemetry Operator, and Smart Gateway Operator. Red Hat does not support the community Operators or workload components, inclusive of Elasticsearch, Prometheus, Alertmanager, Grafana, and their Operators.
 +
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----
@@ -238,8 +222,8 @@ EOF
 ----
 $ oc get csv --selector=operators.coreos.com/elasticsearch-eck-operator-certified.service-telemetry
 
-NAME                                         DISPLAY                        VERSION   REPLACES   PHASE
-elasticsearch-eck-operator-certified.v2.4.0   Elasticsearch (ECK) Operator   2.4.0     elasticsearch-eck-operator-certified.v2.3.0   Succeeded
+NAME                                          DISPLAY                        VERSION   REPLACES                                      PHASE
+elasticsearch-eck-operator-certified.v2.5.0   Elasticsearch (ECK) Operator   2.5.0     elasticsearch-eck-operator-certified.v2.4.0   Succeeded
 ----
 
 ifeval::["{build}" == "upstream"]
@@ -308,11 +292,11 @@ endif::[]
 ----
 $ oc get csv --namespace service-telemetry
 
-NAME                                         DISPLAY                                         VERSION        REPLACES                             PHASE
-amq7-interconnect-operator.v1.10.10          Red Hat Integration - AMQ Interconnect          1.10.10        amq7-interconnect-operator.v1.10.4   Succeeded
-elasticsearch-eck-operator-certified.v2.4.0  Elasticsearch (ECK) Operator                    2.4.0          elasticsearch-eck-operator-certified.v2.3.0   Succeeded
+NAME                                          DISPLAY                                       VERSION          REPLACES                                      PHASE
+amq7-interconnect-operator.v1.10.11           Red Hat Integration - AMQ Interconnect        1.10.11          amq7-interconnect-operator.v1.10.4            Succeeded
+elasticsearch-eck-operator-certified.v2.5.0   Elasticsearch (ECK) Operator                  2.5.0            elasticsearch-eck-operator-certified.v2.4.0   Succeeded
 openshift-cert-manager.v1.7.1                 cert-manager Operator for Red Hat OpenShift   1.7.1-1                                                        Succeeded
-prometheusoperator.0.47.0                    Prometheus Operator                             0.47.0         prometheusoperator.0.37.0            Succeeded
-service-telemetry-operator.v1.5.1664298822   Service Telemetry Operator                      1.5.1664298822                                      Succeeded
-smart-gateway-operator.v5.0.1664298817       Smart Gateway Operator                          5.0.1664298817                                      Succeeded
+prometheusoperator.0.56.3                     Prometheus Operator                           0.56.3           prometheusoperator.0.47.0                     Succeeded
+service-telemetry-operator.v1.5.1668649297    Service Telemetry Operator                    1.5.1668649297                                                 Succeeded
+smart-gateway-operator.v5.0.1668649287        Smart Gateway Operator                        5.0.1668649287                                                 Succeeded
 ----


### PR DESCRIPTION
Remove the use of OperatorHub.io CatalogSource as a location for
Operator subscriptions. There is an updated version of the Promethueus
Operator available in the community-operators CatalogSource (which was
not the case previously), so I think migrating to using that helps
simplify installation instructions. There is an upgrade implication here
though, and we'll need to deal with that as well.
