### PR TITLE
Reference stable-1.5 channel and nightly-1.5 tags

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -46,7 +46,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: InfraWatch Operators
-  image: quay.io/infrawatch-operators/infrawatch-catalog:nightly
+  image: quay.io/infrawatch-operators/infrawatch-catalog:nightly-1.5
   publisher: InfraWatch
   sourceType: grpc
   updateStrategy:
@@ -254,7 +254,7 @@ metadata:
   name: smart-gateway-operator
   namespace: service-telemetry
 spec:
-  channel: unstable
+  channel: stable-1.5
   installPlanApproval: Automatic
   name: smart-gateway-operator
   source: infrawatch-operators
@@ -275,7 +275,7 @@ metadata:
   name: service-telemetry-operator
   namespace: service-telemetry
 spec:
-  channel: unstable
+  channel: stable-1.5
   installPlanApproval: Automatic
   name: service-telemetry-operator
   source: infrawatch-operators


### PR DESCRIPTION
Update the upstream portions of the documentation to refer to the new
stable-1.5 channels which are part of the new infrawatch-catalog index
image with the nightly-1.5 tag, which references built artifacts created
from the stable-1.5 branch of the various STF components.
