### PR TITLE
Add procedure to disable services on OSP side (#407)

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
@@ -37,6 +37,7 @@ include::../modules/proc_creating-the-base-configuration-for-stf.adoc[leveloffse
 include::../modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc[leveloffset=+2]
 include::../modules/proc_deploying-the-overcloud.adoc[leveloffset=+2]
 include::../modules/proc_validating-clientside-installation.adoc[leveloffset=+2]
+include::../modules/proc_disabling-openstack-services-used-with-stf.adoc[leveloffset=+1]
 
 //Sending metrics to Gnocchi and to STF
 ifdef::include_when_16[]

--- a/doc-Service-Telemetry-Framework/modules/proc_disabling-openstack-services-used-with-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_disabling-openstack-services-used-with-stf.adoc
@@ -1,0 +1,57 @@
+[id="disabling-openstack-services-used-with-stf_{context}"]
+= Disabling {OpenStack} services used with {Project}
+
+[role="_abstract"]
+Disable the services used when deploying {OpenStack} ({OpenStackShort}) and connecting it to {Project} ({ProjectShort}).  There is no removal of logs or generated configuration files as part of the disablement of the services.
+
+[WARNING]
+Do not use this procedure when also using the xref:sending-metrics-to-gnocchi-and-to-stf_assembly-completing-the-stf-configuration[] procedure because the `gnocchi-connectors.yaml` does not contain all dependencies required. If you want to remove {ProjectShort}-related services on {OpenStackShort}, ensure that you update your environment to enable data collection and data storage dependencies.
+
+.Procedure
+
+. Log in to the {OpenStackShort} undercloud as the `stack` user.
+
+. Source the authentication file:
++
+[source,bash]
+----
+[stack@undercloud-0 ~]$ source stackrc
+
+(undercloud) [stack@undercloud-0 ~]$
+----
+
+. Create the `disable-stf.yaml` environment file:
++
+[source,yaml,options="nowrap"]
+----
+(undercloud) [stack@undercloud-0]$ cat > $HOME/disable-stf.yaml <<EOF
+---
+resource_registry:
+  OS::TripleO::Services::CeilometerAgentCentral: OS::Heat::None
+  OS::TripleO::Services::CeilometerAgentNotification: OS::Heat::None
+  OS::TripleO::Services::CeilometerAgentIpmi: OS::Heat::None
+  OS::TripleO::Services::ComputeCeilometerAgent: OS::Heat::None
+  OS::TripleO::Services::Redis: OS::Heat::None
+  OS::TripleO::Services::Collectd: OS::Heat::None
+  OS::TripleO::Services::MetricsQdr: OS::Heat::None
+EOF
+----
+
+. Remove the following files from your {OpenStackShort} {OpenStackInstaller} deployment:
++
+* `ceilometer-write-qdr.yaml`
+* `qdr-edge-only.yaml`
+* `enable-stf.yaml`
+* `stf-connectors.yaml`
+
+. Update the {OpenStackShort} overcloud. Ensure that you use the `disable-stf.yaml` file early in the list of environment files. By adding `disable-stf.yaml` early in the list, other environment files can override the configuration that would disable the service:
++
+// this one is actually a valid use of subs +quotes. We want the underbars to result in emphasis when generated.
++
+[source,bash,options="nowrap",subs="+quotes"]
+----
+(undercloud) [stack@undercloud-0 ~]$ openstack overcloud deploy _<other_arguments>_
+--templates /usr/share/openstack-tripleo-heat-templates \
+  --environment-file /home/stack/disable-stf.yaml
+  --environment-file _<other_environment_files>_ \
+----


### PR DESCRIPTION
* Add procedure to disable services on OSP side

Add a procedure that disables the services provisioned when enabling STF.

Resolves: rhbz#2096853

* Add warning to not use procedure with gnocchi

Add a warning to not use the disable procedure when making use of the
Sending metrics to Gnocchi and Service Telemetry Framework procedure
since not all dependencies are provided as part of that instruction set,
since they are a super-set of the STF deployment instructions. In the
future we should probably just remove the Gnocchi deployment
instructions since we've re-written the autoscaling guide and that is
the one procedure that would provide Gnocchi deployments, and would
contain all the necessary dependencies in the provided THT environment
files.

* Apply suggestions from code review

Small changes from jof

* Update doc-Service-Telemetry-Framework/modules/proc_disabling-openstack-services-used-with-stf.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

* Update doc-Service-Telemetry-Framework/modules/proc_disabling-openstack-services-used-with-stf.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

* Update doc-Service-Telemetry-Framework/modules/proc_disabling-openstack-services-used-with-stf.adoc

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

(cherry picked from commit 20d6f11497c0b27053ac9a96369a225bb4187d37)
