### PR TITLE
Minor updates to dashboarding guide (#413)

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_dashboards.adoc
@@ -2,13 +2,13 @@
 = Dashboards in {Project}
 
 [role="_abstract"]
-Use the third-party application, Grafana, to visualize system-level metrics that collectd and Ceilometer gathers for each individual host node.
+Use the third-party application, Grafana, to visualize system-level metrics that the data collectors collectd and Ceilometer gather for each individual host node.
 
-For more information about configuring collectd, see xref:configuring-red-hat-openstack-platform-overcloud-for-stf_assembly-completing-the-stf-configuration[].
+For more information about configuring data collectors, see xref:configuring-red-hat-openstack-platform-overcloud-for-stf_assembly-completing-the-stf-configuration[].
 
 ifdef::include_when_16[]
 //TODO: can re-work this once we have OSP13 dashboard(s) to show. Can't use container health checks or monitoring in OSP13.
-You can use two dashboards to monitor a cloud:
+You can use dashboards to monitor a cloud:
 
 Infrastructure dashboard::
 Use the infrastructure dashboard to view metrics for a single node at a time. Select a node from the upper left corner of the dashboard.
@@ -17,4 +17,10 @@ Cloud view dashboard::
 Use the cloud view dashboard to view panels to monitor service resource usage, API stats, and cloud events. You must enable API health monitoring and service monitoring to provide the data for this dashboard. API health monitoring is enabled by default in the {ProjectShort} base configuration. For more information, see xref:creating-the-base-configuration-for-stf_assembly-completing-the-stf-configuration[].
 ** For more information about API health monitoring, see xref:container-health-and-api-status_assembly-advanced-features[].
 ** For more information about {OpenStackShort} service monitoring, see xref:resource-usage-of-openstack-services_assembly-advanced-features[].
+
+Virtual machine view dashboard::
+Use the virtual machine view dashboard to view panels to monitor virtual machine infrastructure usage. Select a cloud and project from the upper left corner of the dashboard.
+
+Memcached view dashboard::
+Use the memcached view dashboard to view panels to monitor connections, availability, system metrics and cache performance. Select a cloud from the upper left corner of the dashboard.
 endif::include_when_16[]

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -7,6 +7,8 @@ The Grafana Operator can import and manage dashboards by creating `GrafanaDashbo
 
 .Procedure
 
+NOTE: The paths and dashboards names refer to STF 1.3 which is the earliest version of STF the dashboards are compatible and can be used with STF versions 1.3 through 1.5.
+
 . Import the infrastructure dashboard:
 +
 [source,bash,options="nowrap"]

--- a/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc
@@ -45,7 +45,7 @@ NAME                       DISPLAY            VERSION   REPLACES                
 grafana-operator.v4.6.0   Grafana Operator   4.6.0     grafana-operator.v4.5.1   Succeeded
 ----
 
-. To launch a Grafana instance, create or modify the `ServiceTelemetry` object. Set `graphing.enabled` and `graphing.grafana.ingressEnabled` to `true`:
+. To launch a Grafana instance, create or modify the `ServiceTelemetry` object. Set `graphing.enabled` and `graphing.grafana.ingressEnabled` to `true`. Optionally, set the  value of `graphing.grafana.baseImage` to the Grafana workload container image that will be deployed:
 +
 [source,bash]
 ----
@@ -60,6 +60,7 @@ spec:
     enabled: true
     grafana:
       ingressEnabled: true
+      baseImage: 'registry.redhat.io/rhel8/grafana:7'
 ----
 
 . Verify that the Grafana instance deployed:


### PR DESCRIPTION
* Minor updates to dashboarding guide

Perform some minor updates to the dashboarding guide, referencing
existing dashboards we have for virtual machine and memcached views.

Update the ServiceTelemetry manifest to reference the rhel8/grafana:7
container image which should provide more consistency in how things are
deployed, helping avoid a situation where newer versions of Grafana out
of hub.docker.com no longer interface with the version of Elasticsearch
that would be used when enabling events support by default.

Update the path to the dashboards being created to reference the
'stf-1/' directory to reduce confusion by no longer referencing stf-1.3
in the links.

Depends-On: https://github.com/infrawatch/dashboards/pull/50

* Update doc-Service-Telemetry-Framework/modules/con_dashboards.adoc

plural to single

* Update doc-Service-Telemetry-Framework/modules/proc_setting-up-grafana-to-host-the-dashboard.adoc

* Add note about STF 1.3 and revert path change

Revert path changes to the dashboards as use of symlinks as intended is
not possible. Instead, add a note stating that the reference to STF 1.3
is the earliest version compatible with the dashboards, and can be used
with STF versions 1.3 through 1.5.

Co-authored-by: JoanneOFlynn2018 <45287002+JoanneOFlynn2018@users.noreply.github.com>

(cherry picked from commit e23a1b360e3981645bebc8048f67d7bae33279ac)
