### PR TITLE
Fix syntax error in certificate renewal module (#416)

### DIFF
--- a/common/global/stf-attributes.adoc
+++ b/common/global/stf-attributes.adoc
@@ -16,6 +16,10 @@ ifeval::[{vernum} < 16.0]
 :include_when_13:
 endif::[]
 
+ifeval::[{vernum} < 17.0]
+:include_before_17:
+endif::[]
+
 ifeval::[{vernum} >= 17.0]
 :include_when_17:
 endif::[]

--- a/doc-Service-Telemetry-Framework/modules/proc_updating-the-amq-interconnect-ca-certificate.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_updating-the-amq-interconnect-ca-certificate.adoc
@@ -41,13 +41,12 @@ ifdef::include_when_13[]
 [stack@undercloud-0 ~]$ tripleo-ansible-inventory --static-yaml-inventory ./tripleo-ansible-inventory.yaml
 [stack@undercloud-0 ~]$ ansible -i tripleo-ansible-inventory.yaml allovercloud -m shell -a "sudo podman restart metrics_qdr"
 ----
-endif:include_when_13[]
-ifdef::include_when_16[]
+endif::include_when_13[]
+ifdef::include_when_16+include_before_17[]
 ----
 [stack@undercloud-0 ~]$ ansible -i tripleo-ansible-inventory.yaml allovercloud -m shell -a "sudo podman restart metrics_qdr"
 ----
-endif::include_when_16[]
-
+endif::include_when_16+include_before_17[]
 ifdef::include_when_17[]
 ----
 [stack@undercloud-0 ~]$ ansible -i overcloud-deploy/overcloud/tripleo-ansible-inventory.yaml allovercloud -m shell -a "sudo podman restart metrics_qdr"


### PR DESCRIPTION
* Fix syntax error in certificate renewal module

Fix a syntax error in the certificate renewal module. Fixing this
results in another issue that was hidden, whereby extra source lines are
shown when building for version 17.0 due to loose version ranges.
Unfortunately asciidoc doesn't provide an AND function in an ifeval or
ifdef so we need separate parameters defined and nested to perform what
is effectively a greater-than AND less-than evaluation.

This was caught by QE when identifying a link that didn't have a
corresponding section being built. The syntax error on the endif
resulted in everything after that not being built, but did not result in
a build error oddly enough. With this fix, everything is working as
intended and included assemblies after this one are now visible.

* Update ifdef to use AND syntax

Update ifdef to use AND syntax per https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/#checking-multiple-attributes

(cherry picked from commit 1a6cecf44316f9a944c654b28f78101a75b08370)
