### PR TITLE
Update link to STF life cycle page

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_support-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_support-for-stf.adoc
@@ -2,8 +2,8 @@
 = Support for {Project}
 
 [role="_abstract"]
-Red Hat supports the two most recent versions of {Project} ({ProjectShort}). Earlier versions are not supported. For more information, see the https://access.redhat.com/articles/5662081[{Project} Supported Version Matrix].
-
 Red Hat supports the core Operators and workloads, including {MessageBus}, Service Telemetry Operator, and Smart Gateway Operator. Red Hat does not support the community Operators or workload components, such as Elasticsearch, Prometheus, Alertmanager, Grafana, and their Operators.
 
 You can only deploy {ProjectShort} in a fully connected network environment. You cannot deploy {ProjectShort} in {OpenShift}-disconnected environments or network proxy environments.
+
+For more information about {ProjectShort} life cycle and support status, see the https://access.redhat.com/node/6225361[{Project} Supported Version Matrix].


### PR DESCRIPTION
Update the link to the STF life cycle page and remove reference to
supporting the two most recent versions of STF. This has recently
changed. STF 1.4 will be supported until the EOL of OpenShift 4.8 at
which point STF 1.4 will also be EOL. In the meantime STF 1.4 is now in
maintenance mode (CVE fixes only, no backport of features). STF 1.5 is
supported as of 4.10 and will EOL with RHOSP 17.1.
