### PR TITLE
A list of low hanging docs changes from our feature testing

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
@@ -51,7 +51,9 @@ include::../modules/proc_configuring-high-availability.adoc[leveloffset=+2]
 
 //Configuring ephemeral storage
 include::../modules/con_ephemeral-storage.adoc[leveloffset=+1]
+ifeval::["{build}" == "upstream"]
 include::../modules/proc_configuring-ephemeral-storage.adoc[leveloffset=+2]
+endif::[]
 
 //Observability strategy
 include::../modules/con_observability-strategy.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-observability-strategy.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-observability-strategy.adoc
@@ -23,6 +23,13 @@ spec:
 EOF
 ----
 +
+. Delete the left over objects that are managed by community operators
++
+[source,bash]
+----
+$ for o in alertmanager/default prometheus/default elasticsearch/elasticsearch grafana/default lokistack/lokistack; do oc delete $o; done
+----
++
 . To verify that all workloads are operating correctly, view the pods and the status of each pod:
 +
 [source,bash,options="nowrap"]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
@@ -21,10 +21,10 @@ alertmanager.yaml: |-
   - name: 'null'
 ----
 
-To deploy a custom Alertmanager route with {ProjectShort}, you must pass an `alertmanagerConfigManifest` parameter to the Service Telemetry Operator that results in an updated secret, managed by the Prometheus Operator.
+To deploy a custom Alertmanager route with {ProjectShort}, you must add a `alertmanagerConfigManifest` parameter to the Service Telemetry Operator that results in an updated secret, managed by the Prometheus Operator.
 
 [NOTE]
-If your `alertmanagerConfigManifest` contains a custom template to construct the title and text of the sent alert, deploy the contents of the `alertmanagerConfigManifest` using a base64-encoded configuration. For more information, see xref:creating-an-alert-route-with-templating-in-alertmanager_assembly-advanced-features[].
+If your `alertmanagerConfigManifest` contains a custom template, for example, to construct the title and text of the sent alert, you must deploy the contents of the `alertmanagerConfigManifest` using a base64-encoded configuration. For more information, see xref:creating-an-alert-route-with-templating-in-alertmanager_assembly-advanced-features[].
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
@@ -36,7 +36,7 @@ If the `alertmanagerConfigManifest` parameter contains a custom template, for ex
 $ oc project service-telemetry
 ----
 
-. Create the necesarry alermanager config in a file called alertmanager.yaml, for example:
+. Create the necessary alertmanager config in a file called alertmanager.yaml, for example:
 +
 [source,yaml]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
@@ -40,7 +40,7 @@ $ oc project service-telemetry
 +
 [source,yaml]
 ----
-$ cat alertmanager.yaml
+$ cat > alertmanager.yaml <<EOF
 global:
   resolve_timeout: 10m
   slack_api_url: <slack_api_url>
@@ -58,6 +58,7 @@ route:
   group_interval: 5m
   repeat_interval: 12h
   receiver: 'slack'
+EOF
 ----
 . Generate the config manifest and add it to the `ServiceTelemetry` object for your {ProjectShort} deployment:
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
@@ -22,7 +22,7 @@ alertmanager.yaml: |-
   - name: 'null'
 ----
 
-If the `alertmanagerConfigManifest` parameter contains a custom template, for example, to construct the title and text of the sent alert, deploy the contents of the `alertmanagerConfigManifest` by using a base64-encoded configuration.
+If the `alertmanagerConfigManifest` parameter contains a custom template, for example, to construct the title and text of the sent alert, you must deploy the contents of the `alertmanagerConfigManifest` by using a base64-encoded configuration.
 
 .Procedure
 
@@ -36,39 +36,40 @@ If the `alertmanagerConfigManifest` parameter contains a custom template, for ex
 $ oc project service-telemetry
 ----
 
-. Edit the `ServiceTelemetry` object for your {ProjectShort} deployment:
+. Create the necesarry alermanager config in a file called alertmanager.yaml, for example:
 +
-[source,bash]
+[source,yaml]
 ----
-$ oc edit stf default
+$ cat alertmanager.yaml
+global:
+  resolve_timeout: 10m
+  slack_api_url: <slack_api_url>
+receivers:
+  - name: slack
+    slack_configs:
+    - channel: #stf-alerts
+      title: |-
+        ...
+      text: >-
+        ...
+route:
+  group_by: ['job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: 'slack'
 ----
-
-. To deploy a custom Alertmanager route with {ProjectShort}, you must pass an `alertmanagerConfigManifest` parameter to the Service Telemetry Operator that results in an updated secret that is managed by the Prometheus Operator:
+. Generate the config manifest and add it to the `ServiceTelemetry` object for your {ProjectShort} deployment:
 +
-[source,yaml,options="nowrap"]
+[source,bash,options="nowrap"]
 ----
-apiVersion: infra.watch/v1beta1
-kind: ServiceTelemetry
-metadata:
-  name: default
-  namespace: service-telemetry
-spec:
-  backends:
-    metrics:
-      prometheus:
-        enabled: true
-  alertmanagerConfigManifest: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: 'alertmanager-default'
-      namespace: 'service-telemetry'
-    type: Opaque
-    data:
-      alertmanager.yaml: Z2xvYmFsOgogIHJlc29sdmVfdGltZW91dDogMTBtCiAgc2xhY2tfYXBpX3VybDogPHNsYWNrX2FwaV91cmw+CnJlY2VpdmVyczoKICAtIG5hbWU6IHNsYWNrCiAgICBzbGFja19jb25maWdzOgogICAgLSBjaGFubmVsOiAjc3RmLWFsZXJ0cwogICAgICB0aXRsZTogfC0KICAgICAgICAuLi4KICAgICAgdGV4dDogPi0KICAgICAgICAuLi4Kcm91dGU6CiAgZ3JvdXBfYnk6IFsnam9iJ10KICBncm91cF93YWl0OiAzMHMKICBncm91cF9pbnRlcnZhbDogNW0KICByZXBlYXRfaW50ZXJ2YWw6IDEyaAogIHJlY2VpdmVyOiAnc2xhY2snCg==
+$ CONFIG_MANIFEST=$(oc create secret --dry-run=client generic alertmanager-default --from-file=alertmanager.yaml -o json)
+$ oc patch stf default --type=merge -p '{"spec":{"alertmanagerConfigManifest":'"$CONFIG_MANIFEST"'}}'
 ----
-
 . Verify that the configuration has been applied to the secret:
++
+[NOTE]
+There will be a short delay as the operators update each object
 +
 [source,bash,options="nowrap"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
@@ -48,6 +48,19 @@ spec:
 ----
 
 . Save your changes and close the object.
+. Wait for prometheus to restart with the new settings.
++
+[source,bash]
+----
+$ oc get po -l app.kubernetes.io/name=prometheus -w
+----
+. Verify the new retention setting be checking the command line arguments used in the pod.
++
+[source,bash]
+----
+$ oc describe po prometheus-default-0 | grep retention.time
+      --storage.tsdb.retention.time=24h
+----
 
 .Additional resources
 

--- a/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
@@ -54,7 +54,7 @@ spec:
 ----
 $ oc get po -l app.kubernetes.io/name=prometheus -w
 ----
-. Verify the new retention setting be checking the command line arguments used in the pod.
+. Verify the new retention setting by checking the command line arguments used in the pod.
 +
 [source,bash]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_retrieving-and-setting-grafana-login-credentials.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_retrieving-and-setting-grafana-login-credentials.adoc
@@ -2,7 +2,9 @@
 = Retrieving and setting Grafana login credentials
 
 [role="_abstract"]
-{Project} ({ProjectShort}) sets default login credentials when Grafana is enabled. You can override the credentials in the `ServiceTelemetry` object.
+When Grafana is enabled, you can login using openshift authentication, or the default username and password set by the Grafana Operator.
+
+You can override the credentials in the `ServiceTelemetry` object to have {Project} ({ProjectShort}) set the username and password for Grafana instead.
 
 .Procedure
 
@@ -13,7 +15,7 @@
 ----
 $ oc project service-telemetry
 ----
-. Retrieve the default username and password from the {ProjectShort} object:
+. Retrieve the existing username and password from the {ProjectShort} object:
 +
 [source,bash]
 ----
@@ -21,3 +23,14 @@ $ oc get stf default -o jsonpath="{.spec.graphing.grafana['adminUser','adminPass
 ----
 
 . To modify the default values of the Grafana administrator username and password through the ServiceTelemetry object, use the `graphing.grafana.adminUser` and `graphing.grafana.adminPassword` parameters.
++
+[source,bash]
+----
+$ oc edit stf default
+----
+. Wait for the grafana pod to restart with the new credentials in place
++
+[source,bash]
+----
+$ oc get po -l app=grafana -w
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
@@ -14,8 +14,9 @@ TIP: Some telemetry data is available only when {OpenStackShort} has active work
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr
-
+$ sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr ceilometer_agent_notification collectd
+running
+running
 running
 ----
 

--- a/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
@@ -10,16 +10,21 @@ TIP: Some telemetry data is available only when {OpenStackShort} has active work
 
 . Log in to an overcloud node, for example, controller-0.
 
-. Ensure that the `metrics_qdr` container is running on the node:
+. Ensure that the `metrics_qdr` and collection agent containers are running on the node:
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr ceilometer_agent_notification collectd
+$ sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr collectd ceilometer_agent_notification ceilometer_agent_central
+running
 running
 running
 running
 ----
-
++
+[NOTE]
+Use this command on compute nodes:
+sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr collectd ceilometer_agent_compute
++
 . Return the internal network address on which {MessageBus} is running, for example, `172.17.1.44` listening on port `5666`:
 +
 [source,bash,options="nowrap",subs="attributes"]

--- a/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
@@ -22,8 +22,13 @@ running
 ----
 +
 [NOTE]
+====
 Use this command on compute nodes:
-sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr collectd ceilometer_agent_compute
+[source,bash,options="nowrap",subs="attributes"]
+-----
+$ sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr collectd ceilometer_agent_compute
+-----
+====
 +
 . Return the internal network address on which {MessageBus} is running, for example, `172.17.1.44` listening on port `5666`:
 +


### PR DESCRIPTION
Items below are from STF-1167

* OSP Connection 1a Docs: Check other containers, not just metrics_qdr
* Dashboards 1c: Docs: Rewording or change object we source creds from
* Dashboards 1d: Docs: Wait for grafana restart
* Metrics retention 1b:  Docs: Tell customers how to verify
* Alerts 2: Docs: More explicit example of how to construct this config
* HA 2 Docs: Improve alertmanager config docs and re-test
  * Continues to work for me
* Ephemeral Storage Docs: Document this only upstream and/or dev docs
* Observability Strategy Docs: Add a note of which objects to delete
* Docs: Double check that libpodstats and sensubility are not mentioned in OSP 13 (they shouldn't be)
  * I checked here: https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html-single/service_telemetry_framework_1.5/index
  * libpodstats is not mentioned, but sensubility is mentioned in several places
  * Is this a mistake? I don't have an OSP 13 handy and haven't dug through the artifacts to figure it out.
    * If changes are needed, there are several affected locations, so I'll use a dedicated PR
* Certificate Handling (Issue 15.1 or sooner): Set 7.5yr expiry on all certs
  * https://github.com/infrawatch/service-telemetry-operator/pull/389