### PR TITLE
Remove note from importing dashboards procedure

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -7,8 +7,6 @@ The Grafana Operator can import and manage dashboards by creating `GrafanaDashbo
 
 .Procedure
 
-NOTE: The paths and dashboards names refer to STF 1.3 which is the earliest version of STF the dashboards are compatible and can be used with STF versions 1.3 through 1.5.
-
 . Import the infrastructure dashboard:
 +
 [source,bash,options="nowrap"]


### PR DESCRIPTION
Remove the note from the importing dashboards procedure since the paths
no longer refer to STF 1.3.
