### PR TITLE
Adjust network polling meter for ceilometer

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -55,7 +55,8 @@ parameter_defaults:
         - image.*
         - memory
         - memory.*
-        - network.*
+        - network.services.vpn.*
+        - network.services.firewall.*
         - perf.*
         - port
         - port.*
@@ -138,7 +139,8 @@ parameter_defaults:
         - image.*
         - memory
         - memory.*
-        - network.*
+        - network.services.vpn.*
+        - network.services.firewall.*
         - perf.*
         - port
         - port.*


### PR DESCRIPTION
Adjust the broad ceilometer polling meter configuration to be a bit more
specific so that we aren't attempting to poll APIs that no longer exist.

Closes rhbz#2129729
