### PR TITLE
Eliminate vestiges of "stf-default"

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
@@ -179,7 +179,7 @@ endif::[]
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
-  name: stf-default
+  name: default
   namespace: service-telemetry
 spec:
   clouds:

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-ephemeral-storage.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-ephemeral-storage.adoc
@@ -28,7 +28,7 @@ $ oc edit stf default
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
-  name: stf-default
+  name: default
   namespace: service-telemetry
 spec:
   alerting:

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -47,7 +47,7 @@ resource_registry:
 
 parameter_defaults:
     MetricsQdrConnectors:
-        - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch
+        - host: default-interconnect-5671-service-telemetry.apps.infra.watch
           port: 443
           role: edge
           verifyHostname: false

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -74,7 +74,7 @@ resource_registry:
 
 parameter_defaults:
     MetricsQdrConnectors:
-        - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch
+        - host: default-interconnect-5671-service-telemetry.apps.infra.watch
           port: 443
           role: edge
           verifyHostname: false

--- a/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
@@ -33,7 +33,7 @@ If you set a long retention period, retrieving data from heavily populated Prome
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
-  name: stf-default
+  name: default
   namespace: service-telemetry
 spec:
   ...


### PR DESCRIPTION
* I think this used to be the default name long-long ago?
* I made a deployment by cut/pasting the manifest from the ephemeral storage
  * And then all the names mismatched the examples and documented commands