### PR TITLE
Bump base image for building to Fedora 37 (#445)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Test and Publish
       env:
@@ -14,4 +14,4 @@ jobs:
         GH_EMAIL: ${{ secrets.GH_EMAIL }}
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
-        docker run -eBRANCH="${GITHUB_REF##*/}" -eGH_NAME -eGH_EMAIL -eGH_TOKEN --network host -i --volume $PWD:/docs:z --workdir /docs quay.io/fedora/fedora:33-x86_64 /bin/bash -c './build_tools/ci.sh'
+        docker run -eBRANCH="${GITHUB_REF##*/}" -eGH_NAME -eGH_EMAIL -eGH_TOKEN --network host -i --volume $PWD:/docs:z --workdir /docs quay.io/fedora/fedora:37-x86_64 /bin/bash -c './build_tools/ci.sh'

--- a/build_tools/ci.sh
+++ b/build_tools/ci.sh
@@ -17,6 +17,7 @@ make clean html
 
 # Checkout our gh-pages branch, remove everything but .git
 echo "--- switching to gh-pages"
+git config --global --add safe.directory /docs
 git fetch --all
 git checkout gh-pages
 git pull origin gh-pages


### PR DESCRIPTION
* Bump base image for building to Fedora 37

Bump the base image for building in CI to Fedora 37 because Fedora 33 is
now EOL and has been removed from the quay repository.

* Set /docs directory to being marked safe

* Bump actions/checkout v2 (deprecated) to v3