### PR TITLE
mg_master_2168184_adding section with procedures for upgrade from 1.4…

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-5.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-5.adoc
@@ -1,0 +1,58 @@
+ifdef::context[:parent-context-of-upgrading-service-telemetry-framework-to-version-1-5: {context}]
+
+////
+file name: assembly_upgrading-service-telemetry-framework-to-version-1-5.adoc
+ID: [id="assembly_upgrading-service-telemetry-framework-to-version-1-5_{context}"]
+Title: = Upgrading Service Telemetry Framework to version 1.5
+////
+
+:_content-type: ASSEMBLY
+
+ifndef::context[]
+[id="upgrading-service-telemetry-framework-to-version-1-5"]
+endif::[]
+ifdef::context[]
+[id="upgrading-service-telemetry-framework-to-version-1-5_{context}"]
+endif::[]
+
+= Upgrading {Project} to version 1.5
+
+:context: upgrading-service-telemetry-framework-to-version-1-5
+
+To upgrade {Project} ({ProjectShort}) 1.4 to {ProjectShort} 1.5, you must complete the following steps:
+
+* Replace AMQ Certificate Manager with Certificate Manager.
+* Remove the `ClusterServiceVersion` and `Subscription` objects for Smart Gateway Operator and Service Telemetry Operator in the `service-telemetry` namespace on your {OpenShift} environment.
+
+* Upgrade {OpenShift} from 4.8 to 4.10.
+
+* Re-enable the operators that you removed.
+ifdef::include_when_13,include_when_17[* Update the {MessageBus} CA Certificate on {OpenStack} ({OpenStackShort}).]
+
+.Prerequisites
+
+* You have backed up your data. There is an outage during the {OpenShift} upgrade. You cannot reconfigure the `ServiceTelemetry` and `SmartGateway` objects during the Operators replacement.
+* You have prepared your environment for upgrade from {OpenShift} 4.8 to the supported version, 4.10.
+* The {OpenShift} cluster is fully-connected. {ProjectShort} does not support disconnected or restricted-network clusters.
+
+include::../modules/proc_removing-the-service-telemetry-framework-1-4-operators.adoc[leveloffset=+1]
+
+// This is "sub-procedure" of proc_removing-the-service-telemetry-framework-v1-4-operators.adoc
+include::../modules/proc_removing-the-service-telemetry-operator.adoc[leveloffset=+2]
+// This is "sub-procedure" of proc_removing-the-service-telemetry-framework-v1-4-operators.adoc
+include::../modules/proc_removing-the-smart-gateway-operator.adoc[leveloffset=+2]
+// This is "sub-procedure" of proc_removing-the-service-telemetry-framework-v1-4-operators.adoc
+include::../modules/proc_removing-the-amq-certificate-manager-operator.adoc[leveloffset=+2]
+// This is "sub-procedure" of proc_removing-the-service-telemetry-framework-v1-4-operators.adoc
+include::../modules/proc_removing-the-grafana-operator.adoc[leveloffset=+2]
+
+include::../modules/proc_upgrading-red-hat-openshift-container-platform-to-4-10.adoc[leveloffset=+1]
+
+include::../modules/proc_installing-the-service-telemetry-framework-1-5-operators.adoc[leveloffset=+1]
+
+ifdef::include_when_13,include_when_17[]
+include::../modules/proc_updating-the-amq-interconnect-ca-certificate-on-red-hat-openstack-platform.adoc[leveloffset=+1]
+endif::include_when_13,include_when_17[]
+
+ifdef::parent-context-of-upgrading-service-telemetry-framework-to-version-1-5[:context: {parent-context-of-upgrading-service-telemetry-framework-to-version-1-5}]
+ifndef::parent-context-of-upgrading-service-telemetry-framework-to-version-1-5[:!context:]

--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -37,10 +37,10 @@ include::assemblies/assembly_advanced-features.adoc[leveloffset=+1]
 //certificate renewal
 include::assemblies/assembly_renewing-the-amq-interconnect-certificate.adoc[leveloffset=+1]
 
-// upgrading to 1.4
-//include::assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-4.adoc[leveloffset=+1]
-
 // removing
 include::assemblies/assembly_removing-stf-from-the-openshift-environment.adoc[leveloffset=+1]
 
 //collectd plugins
+
+// upgrading to 1.5
+include::assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-5.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/modules/proc_installing-the-service-telemetry-framework-1-5-operators.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_installing-the-service-telemetry-framework-1-5-operators.adoc
@@ -1,0 +1,163 @@
+////
+* file name: proc_installing-the-service-telemetry-framework-1-5-operators.adoc
+* ID: [id="proc_installing-the-service-telemetry-framework-1-5-operators_{context}"]
+* Title: = Installing the Service Telemetry Framework 1.5 Operators
+////
+
+:_content-type: PROCEDURE
+
+[id="installing-the-service-telemetry-framework-1-5-operators_{context}"]
+= Installing the {Project} 1.5 Operators
+
+Install the {Project} ({ProjectShort}) 1.5 Operators and the Certificate Manager for OpenShift Operator on your {OpenShift} 4.10 environment. {ProjectShort} 1.5 only supports {OpenShift} 4.10. Installing {ProjectShort} into disconnected or restricted network environments is unsupported.
+
+ifdef::include_when_13,include_when_17[]
+[NOTE]
+After a successful {ProjectShort} 1.5 install, you must retrieve and apply the {MessageBus} CA certificate to the {OpenStack} environment, or the transport layer and telemetry data becomes unavailable.
+
+For more information about updating the {MessageBus} CA certificate, see xref:updating-the-amq-interconnect-ca-certificate-on-red-hat-openstack-platform_upgrading-service-telemetry-framework-to-version-1-5[].
+endif::include_when_13,include_when_17[]
+
+.Prerequisites
+
+* You have upgraded your {OpenShift} environment to 4.10.
+For more information about upgrading {OpenShift}, see xref:upgrading-red-hat-openshift-container-platform-to-4-10_upgrading-service-telemetry-framework-to-version-1-5[].
+* Your {OpenShift} environment network is fully-connected.
+
+.Procedure
+
+. Change to the `service-telemetry` project:
++
+[source,bash]
+----
+$ oc project service-telemetry
+----
+
+. Create a `namespace` for the `cert-manager` Operator:
++
+[source,bash]
+----
+$ oc create -f - <<EOF
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: openshift-cert-manager-operator
+spec:
+  finalizers:
+  - kubernetes
+EOF
+----
+
+. Create an `OperatorGroup` for the cert-manager Operator:
++
+[source,bash]
+----
+$ oc create -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: openshift-cert-manager-operator
+spec: {}
+EOF
+----
+
+. Subscribe to the `cert-manager` Operator with the `redhat-operators` CatalogSource:
++
+[source,bash]
+----
+$ oc create -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: openshift-cert-manager-operator
+spec:
+  channel: tech-preview
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+----
+
+. Validate your `ClusterServiceVersion`. Ensure that the phase of `cert-manager` Operator is `Succeeded`:
++
+[source,bash,options="nowrap"]
+----
+$ oc get csv --namespace openshift-cert-manager-operator --selector=operators.coreos.com/openshift-cert-manager-operator.openshift-cert-manager-operator
+
+NAME                            DISPLAY                                       VERSION   REPLACES   PHASE
+openshift-cert-manager.v1.7.1   cert-manager Operator for Red Hat OpenShift   1.7.1-1              Succeeded
+----
+
+. Optional: Resubscribe to the Grafana Operator. For more information, see: test xref:setting-up-grafana-to-host-the-dashboard_assembly-advanced-features[].
+
+. Create the Service Telemetry Operator subscription to manage the {ProjectShort} instances:
++
+[source,bash]
+----
+$ oc create -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: service-telemetry-operator
+  namespace: service-telemetry
+spec:
+  channel: stable-1.5
+  installPlanApproval: Automatic
+  name: service-telemetry-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+----
+
+. Validate the Service Telemetry Operator and the dependent operators:
++
+[source,bash,options="nowrap"]
+----
+$ oc get csv --namespace service-telemetry
+
+NAME                                          DISPLAY                                       VERSION          REPLACES                                      PHASE
+amq7-interconnect-operator.v1.10.13           Red Hat Integration - AMQ Interconnect        1.10.13          amq7-interconnect-operator.v1.10.4            Succeeded
+elasticsearch-eck-operator-certified.v2.5.0   Elasticsearch (ECK) Operator                  2.5.0            elasticsearch-eck-operator-certified.v2.4.0   Succeeded
+openshift-cert-manager.v1.7.1                 cert-manager Operator for Red Hat OpenShift   1.7.1-1                                                        Succeeded
+prometheusoperator.0.47.0                     Prometheus Operator                           0.47.0           prometheusoperator.0.37.0                     Succeeded
+service-telemetry-operator.v1.5.1669950702    Service Telemetry Operator                    1.5.1669950702                                                 Succeeded
+smart-gateway-operator.v5.0.1669950681        Smart Gateway Operator                        5.0.1669950681                                                 Succeeded
+----
+
+.Verification
+
+* Verify that the Service Telemetry Operator has successfully reconciled.
++
+[source,bash,options="nowrap"]
+----
+$ oc logs -f --selector=name=service-telemetry-operator
+
+[...]
+----- Ansible Task Status Event StdOut (infra.watch/v1beta1, Kind=ServiceTelemetry, default/service-telemetry) -----
+
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=115  changed=0    unreachable=0    failed=0    skipped=21   rescued=0    ignored=0
+
+
+$ oc get pods
+NAME                                                      READY   STATUS    RESTARTS        AGE
+alertmanager-default-0                                    3/3     Running   0               20h
+default-cloud1-ceil-event-smartgateway-6d57ffbbdc-5mrj8   2/2     Running   1 (3m42s ago)   4m21s
+default-cloud1-ceil-meter-smartgateway-67684d88c8-62mp7   3/3     Running   1 (3m43s ago)   4m20s
+default-cloud1-coll-event-smartgateway-66cddd5567-qb6p2   2/2     Running   1 (3m42s ago)   4m19s
+default-cloud1-coll-meter-smartgateway-76d5ff6db5-z5ch8   3/3     Running   0               4m20s
+default-cloud1-sens-meter-smartgateway-7b59669fdd-c42zg   3/3     Running   1 (3m43s ago)   4m20s
+default-interconnect-845c4b647c-wwfcm                     1/1     Running   0               4m10s
+elastic-operator-57b57964c5-6q88r                         1/1     Running   8 (17h ago)     20h
+elasticsearch-es-default-0                                1/1     Running   0               21h
+grafana-deployment-59c54f7d7c-zjnhm                       2/2     Running   0               20h
+interconnect-operator-848889bf8b-bq2zx                    1/1     Running   0               20h
+prometheus-default-0                                      3/3     Running   1 (20h ago)     20h
+prometheus-operator-5d7b69fd46-c2xlv                      1/1     Running   0               20h
+service-telemetry-operator-79fb664dfb-nj8jn               1/1     Running   0               5m11s
+smart-gateway-operator-79557664f8-ql7xr                   1/1     Running   0               5m7s
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_removing-the-amq-certificate-manager-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_removing-the-amq-certificate-manager-operator.adoc
@@ -1,0 +1,59 @@
+////
+* file name: proc_removing-the-amq-certificate-manager-operator.adoc
+* ID: [id="proc_removing-the-amq-certificate-manager-operator_{context}"]
+* Title: = Removing the AMQ Certificate Manager Operator
+////
+
+:_content-type: PROCEDURE
+
+[id="removing-the-amq-certificate-manager-operator_{context}"]
+= Removing the AMQ Certificate Manager Operator
+
+.Procedure
+
+. Remove the AMQ Certificate Manager Operator Subscription:
++
+[source,bash]
+----
+$ oc delete sub --namespace openshift-operators --selector=operators.coreos.com/amq7-cert-manager-operator.openshift-operators
+
+subscription.operators.coreos.com "amq7-cert-manager-operator" deleted
+----
+
+. Remove the AMQ Certificate Manager Operator `ClusterServiceVersion`:
++
+[source,bash]
+----
+$ oc delete csv --namespace openshift-operators --selector=operators.coreos.com/amq7-cert-manager-operator.openshift-operators
+
+clusterserviceversion.operators.coreos.com "amq7-cert-manager.v1.0.11" deleted
+----
+
+.Verification
+
+. Verify that the AMQ Certificate Manager Operator deployment is not running:
++
+[source,bash]
+----
+$ oc get deploy --namespace openshift-operators --selector=operators.coreos.com/amq7-cert-manager-operator.openshift-operators
+
+No resources found in openshift-operators namespace.
+----
+
+. Verify that the AMQ Certificate Manager Operator subscription is absent:
++
+[source,bash]
+----
+$ oc get sub --namespace openshift-operators --selector=operators.coreos.com/amq7-cert-manager-operator.service-telemetry
+
+No resources found in openshift-operators namespace.
+----
+
+. Verify that the AMQ Certificate Manager Operator Cluster Service Version is absent:
++
+[source,bash]
+----
+$ oc get csv --namespace openshift-operators --selector=operators.coreos.com/amq7-cert-manager-operator.openshift-operators
+
+No resources found in openshift-operators namespace.
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_removing-the-grafana-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_removing-the-grafana-operator.adoc
@@ -1,0 +1,59 @@
+////
+* file name: proc_removing-the-grafana-operator.adoc
+* ID: [id="proc_removing-the-grafana-operator_{context}"]
+* Title: = Removing the Grafana Operator
+////
+
+:_content-type: PROCEDURE
+
+[id="removing-the-grafana-operator_{context}"]
+= Removing the Grafana Operator
+
+.Procedure
+
+. Remove the Grafana Operator Subscription:
++
+[source,bash]
+----
+$ oc delete sub --selector=operators.coreos.com/grafana-operator.service-telemetry
+
+subscription.operators.coreos.com "grafana-operator" deleted
+----
+
+. Remove the Grafana Operator `ClusterServiceVersion`:
++
+[source,bash]
+----
+$ oc delete csv --selector=operators.coreos.com/grafana-operator.service-telemetry
+
+clusterserviceversion.operators.coreos.com "grafana-operator.v3.10.3" deleted
+----
+
+.Verification
+
+. Verify the Grafana Operator deployment is not running:
++
+[source,bash]
+----
+$ oc get deploy --selector=operators.coreos.com/grafana-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----
+
+. Verify the Grafana Operator subscription is absent:
++
+[source,bash]
+----
+$ oc get sub --selector=operators.coreos.com/grafana-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----
+
+. Verify the Grafana Operator Cluster Service Version is absent:
++
+[source,bash]
+----
+$ oc get csv --selector=operators.coreos.com/grafana-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_removing-the-service-telemetry-framework-1-4-operators.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_removing-the-service-telemetry-framework-1-4-operators.adoc
@@ -1,0 +1,24 @@
+////
+Base the file name and the ID on the module title. For example:
+* file name: proc_removing-the-service-telemetry-framework-1-4-operators.adoc
+* ID: [id="proc_removing-the-service-telemetry-framework-1-4-operators_{context}"]
+* Title: = Removing the Service Telemetry Framework 1.4 Operators
+////
+:_content-type: PROCEDURE
+
+[id="removing-the-service-telemetry-framework-1-4-operators_{context}"]
+= Removing the {Project} 1.4 Operators
+
+Remove the {Project} ({ProjectShort}) 1.4 Operators and the AMQ Certificate Manager Operator from the {OpenShift} 4.8.
+
+.Procedure
+
+. Remove the Service Telemetry Operator.
+. Remove the Smart Gateway Operator.
+. Remove the AMQ Certificate Manager Operator.
+. Remove the Grafana Operator.
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about removing Operators from the {OpenShift}, see link:https://docs.openshift.com/container-platform/4.8/operators/admin/olm-deleting-operators-from-cluster.html[Deleting Operators from a cluster].

--- a/doc-Service-Telemetry-Framework/modules/proc_removing-the-service-telemetry-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_removing-the-service-telemetry-operator.adoc
@@ -1,0 +1,67 @@
+////
+* file name: proc_removing-the-service-telemetry-operator.adoc
+* ID: [id="proc_removing-the-service-telemetry-operator_{context}"]
+* Title: = Removing the Service Telemetry Operator
+////
+:_content-type: PROCEDURE
+
+[id="removing-the-service-telemetry-operator_{context}"]
+= Removing the Service Telemetry Operator
+
+As part of upgrading your {Project} ({ProjectShort}) installation, you must remove the Service Telemetry Operator in the `service-telemetry` namespace on your {OpenShift} environment.
+
+.Procedure
+
+. Change to the `service-telemetry` project:
++
+[source,bash]
+----
+$ oc project service-telemetry
+----
+
+. Remove the Service Telemetry Operator Subscription:
++
+[source,bash]
+----
+$ oc delete sub --selector=operators.coreos.com/service-telemetry-operator.service-telemetry
+
+subscription.operators.coreos.com "service-telemetry-operator" deleted
+----
+
+. Remove the Service Telemetry Operator `ClusterServiceVersion`:
++
+[source,bash]
+----
+$ oc delete csv --selector=operators.coreos.com/service-telemetry-operator.service-telemetry
+
+clusterserviceversion.operators.coreos.com "service-telemetry-operator.v1.4.1669718959" deleted
+----
+
+.Verification
+
+. Verify that the Service Telemetry Operator deployment is not running:
++
+[source,bash]
+----
+$ oc get deploy --selector=operators.coreos.com/service-telemetry-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----
+
+. Verify the Service Telemetry Operator subscription is absent:
++
+[source,bash]
+----
+$ oc get sub --selector=operators.coreos.com/service-telemetry-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----
+
+. Verify the Service Telemetry Operator ClusterServiceVersion is absent:
++
+[source,bash]
+----
+$ oc get csv --selector=operators.coreos.com/service-telemetry-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_removing-the-smart-gateway-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_removing-the-smart-gateway-operator.adoc
@@ -1,0 +1,69 @@
+////
+* file name: proc_removing-the-smart-gateway-operator.adoc
+* ID: [id="proc_removing-the-smart-gateway-operator_{context}"]
+* Title: = Removing the Smart Gateway Operator
+////
+
+:_content-type: PROCEDURE
+
+[id="removing-the-smart-gateway-operator_{context}"]
+= Removing the Smart Gateway Operator
+
+As part of upgrading your {Project} ({ProjectShort}) installation, you must remove the Smart Gateway Operator in the `service-telemetry` namespace on your {OpenShift} environment.
+
+.Procedure
+
+. Change to the `service-telemetry` project:
++
+[source,bash]
+----
+$ oc project service-telemetry
+----
+
+. Remove the Smart Gateway Operator Subscription:
++
+[source,bash]
+----
+$ oc delete sub --selector=operators.coreos.com/smart-gateway-operator.service-telemetry
+
+subscription.operators.coreos.com "smart-gateway-operator-stable-1.4-redhat-operators-openshift-marketplace" deleted
+----
+
+. Remove the Smart Gateway Operator `ClusterServiceVersion`:
++
+[source,bash]
+----
+$ oc delete csv --selector=operators.coreos.com/smart-gateway-operator.service-telemetry
+
+clusterserviceversion.operators.coreos.com "smart-gateway-operator.v4.0.1669718962" deleted
+----
+
+.Verification
+
+
+. Verify that the Smart Gateway Operator deployment is not running:
++
+[source,bash]
+----
+$ oc get deploy --selector=operators.coreos.com/smart-gateway-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----
+
+. Verify the Smart Gateway Operator subscription is absent:
++
+[source,bash]
+----
+$ oc get sub --selector=operators.coreos.com/smart-gateway-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----
+
+. Verify the Smart Gateway Operator ClusterServiceVersion is absent:
++
+[source,bash]
+----
+$ oc get csv --selector=operators.coreos.com/smart-gateway-operator.service-telemetry
+
+No resources found in service-telemetry namespace.
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_updating-the-amq-interconnect-ca-certificate-on-red-hat-openstack-platform.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_updating-the-amq-interconnect-ca-certificate-on-red-hat-openstack-platform.adoc
@@ -1,0 +1,20 @@
+////
+* file name: proc_updating-the-amq-interconnect-ca-certificate-on-red-hat-openstack-platform.adoc
+* ID: [id="proc_updating-the-amq-interconnect-ca-certificate-on-red-hat-openstack-platform_{context}"]
+* Title: = Updating the AMQ Interconnect CA Certificate on Red Hat OpenStack Platform
+////
+
+:_content-type: PROCEDURE
+
+[id="updating-the-amq-interconnect-ca-certificate-on-red-hat-openstack-platform_{context}"]
+= Updating the {MessageBus} CA Certificate on {OpenStack}
+
+After you upgrade to {Project} ({ProjectShort}) v1.5, the CA certificate for {MessageBus} regenerates. In {ProjectShort} v1.4 the CA certificate for {MessageBus} is valid for three months and must be updated periodically in {OpenStack} ({OpenStackShort}). In {ProjectShort} v1.5, the generated certificates are valid for the lifetime of the {OpenStackShort} lifecycle, 70080 hours by default.
+
+.Prerequisites
+
+* You have successfully installed {ProjectShort} v1.5 and updated the CA certificate for {MessageBus}.
+
+.Procedure
+
+* For more information about how to update the CA certificate in your {OpenStackShort} environment, see xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]

--- a/doc-Service-Telemetry-Framework/modules/proc_upgrading-red-hat-openshift-container-platform-to-4-10.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_upgrading-red-hat-openshift-container-platform-to-4-10.adoc
@@ -1,0 +1,32 @@
+////
+* file name: proc_upgrading-red-hat-openshift-container-platform-to-4-10.adoc
+* ID: [id="proc_upgrading-red-hat-openshift-container-platform-to-4-10_{context}"]
+* Title: = Upgrading Red Hat OpenShift Container Platform to 4.10
+////
+
+:_content-type: PROCEDURE
+
+[id="upgrading-red-hat-openshift-container-platform-to-4-10_{context}"]
+= Upgrading {OpenShift} to 4.10
+
+{Project} ({ProjectShort}) 1.5 is only compatible with {OpenShift} 4.10. For more information about upgrading your {OpenShift} from 4.8 to 4.10, see link:https://docs.openshift.com/container-platform/4.8/updating/index.html[Updating clusters overview].
+
+.Prerequisites
+
+* You removed the {ProjectShort} 1.4 Operators.
+
+* You removed the AMQ Certificate Manager Operator and Grafana Operator. You must remove the Operators before you upgrade {OpenShift} because the Operator APIs are incompatible with 4.10. For more information about preparing your {OpenShift} for upgrade from 4.8 to 4.10, see link:https://docs.openshift.com/container-platform/4.8/updating/understanding-openshift-updates.html[Understanding OpenShift Container Platform updates].
+
+* Verify the suitability of your {OpenShift} upgrade:
++
+[source,bash]
+----
+$ oc adm upgrade
+----
++
+You cannot upgrade the cluster if you encounter the following error message:
++
+[source,bash]
+----
+Cluster operator operator-lifecycle-manager should not be upgraded between minor versions: ClusterServiceVersions blocking cluster upgrade: service-telemetry/grafana-operator.v3.10.3 is incompatible with OpenShift minor versions greater than 4.8,openshift-operators/amq7-cert-manager.v1.0.11 is incompatible with OpenShift minor versions greater than 4.8
+----


### PR DESCRIPTION
…… (#444)

* mg_master_2168184_adding section with procedures for upgrade from 1.4 to 1.5

* Bump base image for building to Fedora 37 (#445)

* Bump base image for building to Fedora 37

Bump the base image for building in CI to Fedora 37 because Fedora 33 is now EOL and has been removed from the quay repository.

* Set /docs directory to being marked safe

* Bump actions/checkout v2 (deprecated) to v3

* Update doc-Service-Telemetry-Framework/assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-5.adoc

* commit 2, incorporating feedback mg_master_2168184_procedures-to-upgrade-from-1.4-to-1.5

* commit 3, fixed internal link to Grafana section mg_master_2168184_procedures-to-upgrade-from-1.4-to-1.5

* mg_master_2168184_procedures-to-upgrade-from-1.4-to-1.5 commit Feb 14th

* Add ifdef wrappers for certificate parts (#447)

* Add ifdef wrappers for certificate documentation parts which do not apply to OSP16 (only 13 and 17).
* Add a couple of clean up items for consistency and visual bits.

* mg_master_2168184_procedures-to-upgrade-from-1.4-to-1.5 commit Feb 17

Rebased

---------