### PR TITLE
Expose ability to set certificate renewal target times

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
@@ -45,6 +45,10 @@ include::../modules/proc_creating-an-alert-route-with-templating-in-alertmanager
 //SNMP Traps
 include::../modules/proc_configuring-snmp-traps.adoc[leveloffset=+1]
 
+//TLS Certificates duration
+include::../modules/con_tls-certificates-duration.adoc[leveloffset=+1]
+include::../modules/proc_configuring-tls-certificates-duration.adoc[leveloffset=+2]
+
 //High availability
 include::../modules/con_high-availability.adoc[leveloffset=+1]
 include::../modules/proc_configuring-high-availability.adoc[leveloffset=+2]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
@@ -46,8 +46,10 @@ include::../modules/proc_creating-an-alert-route-with-templating-in-alertmanager
 include::../modules/proc_configuring-snmp-traps.adoc[leveloffset=+1]
 
 //TLS Certificates duration
+ifdef::include_when_13,include_when_17[]
 include::../modules/con_tls-certificates-duration.adoc[leveloffset=+1]
 include::../modules/proc_configuring-tls-certificates-duration.adoc[leveloffset=+2]
+endif::include_when_13,include_when_17[]
 
 //High availability
 include::../modules/con_high-availability.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
@@ -1,0 +1,68 @@
+[id="tls-certificates-duration_{context}"]
+= Configuring the duration for the TLS certificates
+
+[role="_abstract"]
+You can configure the duration for the TLS certificates used for the connections with
+ElasticSearch and Apache Qpid Dispatch Router in {Project} ({ProjectShort}). To do so,
+modify the `ServiceTelemetry` object and configure the `certificates` parameters.
+
+[id="configuration-parameters-for-tls-certificates-duration_{context}"]
+== Configuration parameters for the TLS certificates
+
+The `certificates` parameter contains the following sub-parameters for configuring the
+certificates duration:
+
+endpointCertDuration:: The requested 'duration' (i.e. lifetime) of the endpoint Certificate.
+Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+Default value is `70128h`.
+caCertDuration:: The requested 'duration' (i.e. lifetime) of the CA Certificate.
+Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+Default value is `70128h`.
+
+NOTE:: Certificates are by default long lived considering a subset of them are expected to be copied in the {OpenStack}
+deployment when they renew. Fore more information about the QDR CA Certificate renewal process, see
+xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
+
+The `certificates` parameter for ElasticSearch is part of the `backends.events.elasticsearch` definition and is configured in the `ServiceTelemetry` object:
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+...
+  backends:
+    ...
+    events:
+      elasticsearch:
+        enabled: true
+        version: 7.16.1
+        certificates:
+          endpointCertDuration: 70080h
+          caCertDuration: 70080h
+...
+----
+
+The `certificates` parameter for QDR is part of the `transports.qdr` definition and is configured in the `ServiceTelemetry` object:
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+...
+  transports:
+    ...
+    qdr:
+      enabled: true
+      certificates:
+        endpointCertDuration: 70080h
+        caCertDuration: 70080h
+...
+----

--- a/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
@@ -2,26 +2,23 @@
 = Configuring the duration for the TLS certificates
 
 [role="_abstract"]
-You can configure the duration for the TLS certificates used for the connections with
-Elasticsearch and {MessageBus} in {Project} ({ProjectShort}). To do so,
+To configure the duration of the TLS certificates that you use for the connections with
+Elasticsearch and {MessageBus} in {Project} ({ProjectShort}),
 modify the `ServiceTelemetry` object and configure the `certificates` parameters.
 
 [id="configuration-parameters-for-tls-certificates-duration_{context}"]
 == Configuration parameters for the TLS certificates
 
-The `certificates` parameter contains the following sub-parameters for configuring the
-certificates duration:
+You can configure the duration of the certificate with the following sub-parameters of the `certificates` parameter:
 
-endpointCertDuration:: The requested 'duration' (i.e. lifetime) of the endpoint Certificate.
+endpointCertDuration:: The requested 'duration' or lifetime of the endpoint Certificate.
+Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+The default value is `70080h`.
+caCertDuration:: The requested 'duration' or lifetime of the CA Certificate.
 Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
 Default value is `70080h`.
-caCertDuration:: The requested 'duration' (i.e. lifetime) of the CA Certificate.
-Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
-Default value is `70080h`.
 
-NOTE:: Certificates are by default long lived considering a subset of them are expected to be copied in the {OpenStack}
-deployment when they renew. For more information about the QDR CA Certificate renewal process, see
-xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
+NOTE:: The default duration of certificates is long, because you usually copy a subset of them in the {OpenStack} deployment when the certificates renew. For more information about the QDR CA Certificate renewal process, see xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
 
 The `certificates` parameter for Elasticsearch is part of the `backends.events.elasticsearch` definition and is configured in the `ServiceTelemetry` object:
 
@@ -46,7 +43,7 @@ spec:
 ...
 ----
 
-The `certificates` parameter for QDR is part of the `transports.qdr` definition and is configured in the `ServiceTelemetry` object:
+You can configure the `certificates` parameter for QDR that is part of the `transports.qdr` definition in the `ServiceTelemetry` object:
 
 [source,yaml,options="nowrap"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
@@ -3,7 +3,7 @@
 
 [role="_abstract"]
 You can configure the duration for the TLS certificates used for the connections with
-ElasticSearch and Apache Qpid Dispatch Router in {Project} ({ProjectShort}). To do so,
+Elasticsearch and {MessageBus} in {Project} ({ProjectShort}). To do so,
 modify the `ServiceTelemetry` object and configure the `certificates` parameters.
 
 [id="configuration-parameters-for-tls-certificates-duration_{context}"]
@@ -14,16 +14,16 @@ certificates duration:
 
 endpointCertDuration:: The requested 'duration' (i.e. lifetime) of the endpoint Certificate.
 Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
-Default value is `70128h`.
+Default value is `70080h`.
 caCertDuration:: The requested 'duration' (i.e. lifetime) of the CA Certificate.
 Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
-Default value is `70128h`.
+Default value is `70080h`.
 
 NOTE:: Certificates are by default long lived considering a subset of them are expected to be copied in the {OpenStack}
 deployment when they renew. Fore more information about the QDR CA Certificate renewal process, see
 xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
 
-The `certificates` parameter for ElasticSearch is part of the `backends.events.elasticsearch` definition and is configured in the `ServiceTelemetry` object:
+The `certificates` parameter for Elasticsearch is part of the `backends.events.elasticsearch` definition and is configured in the `ServiceTelemetry` object:
 
 [source,yaml,options="nowrap"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
@@ -20,7 +20,7 @@ Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.
 Default value is `70080h`.
 
 NOTE:: Certificates are by default long lived considering a subset of them are expected to be copied in the {OpenStack}
-deployment when they renew. Fore more information about the QDR CA Certificate renewal process, see
+deployment when they renew. For more information about the QDR CA Certificate renewal process, see
 xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
 
 The `certificates` parameter for Elasticsearch is part of the `backends.events.elasticsearch` definition and is configured in the `ServiceTelemetry` object:

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-tls-certificates-duration.adoc
@@ -10,16 +10,15 @@ For this purpose, modify the `ServiceTelemetry` object and configure the `certif
 * Verify you don't have an instance of Service Telemetry Operator already deployed.
 
 NOTE:: Once created the `ServiceTelemetry` object, the required certificates and their secrets for {Project} ({ProjectShort}) are created.
-In order to modify these you must follow a procedure similar to the one present in xref:xref:assembly-renewing-the-amq-interconnect-certificate_assembly[].
-The following procedure is valid for greenfield {Project} ({ProjectShort}) deployments.
+In order to modify these you must follow a procedure similar to the one present in xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
+The following procedure is valid for new {Project} ({ProjectShort}) deployments.
 
 .Procedure
 
-+
 To override the duration of the TLS certificates, define which certificate you want to override.
-In this example, set Elasticsearch endpoint certificates duration to 3 years by setting `endpointCertDuration` to `26280h`
-and set QDR CA Certificates duration to 10 years by setting `caCertDuration` to `87600h`.
-Keep the default for the other certificates (CA certificates for Elasticsearch and endpoint certificates for QDR will keep the value of 8 years):
+For example, set the Elasticsearch endpoint certificate duration to 3 years by setting `endpointCertDuration` to `26280h`
+and set QDR CA certificate duration to 10 years by setting `caCertDuration` to `87600h`.
+Keep the default value for the other certificates (CA certificate for Elasticsearch and endpoint certificate for QDR will keep the value of 8 years):
 +
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-tls-certificates-duration.adoc
@@ -1,0 +1,58 @@
+[id="configuring-tls-certificates-duration_{context}"]
+= Configuring TLS certificates duration
+
+[role="_abstract"]
+You can configure the duration of the TLS certificates to use with {Project} ({ProjectShort}) to fit your deployment needs.
+For this purpose, modify the `ServiceTelemetry` object and configure the `certificates` parameter.
+
+.Prerequisites
+
+* Verify you don't have an instance of Service Telemetry Operator already deployed.
+
+NOTE:: Once created the `ServiceTelemetry` object, the required certificates and their secrets for {Project} ({ProjectShort}) are created.
+In order to modify these you must follow a procedure similar to the one present in xref:xref:assembly-renewing-the-amq-interconnect-certificate_assembly[].
+The following procedure is valid for greenfield {Project} ({ProjectShort}) deployments.
+
+.Procedure
+
++
+To override the duration of the TLS certificates, define which certificate you want to override.
+In this example, set Elasticsearch endpoint certificates duration to 3 years by setting `endpointCertDuration` to `26280h`
+and set QDR CA Certificates duration to 10 years by setting `caCertDuration` to `87600h`.
+Keep the default for the other certificates (CA certificates for Elasticsearch and endpoint certificates for QDR will keep the value of 8 years):
++
+[source,yaml,options="nowrap",role="white-space-pre"]
+----
+$ oc apply -f - <<EOF
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+  backends:
+    events:
+      elasticsearch:
+        enabled: true
+        certificates:
+          endpointCertDuration: 26280h
+  transport:
+    qdr:
+      enabled: true
+      certificates:
+        caCertDuration: 87600h
+EOF
+----
+
+.Verification
+
+. Verify that the desired expiry date appears in the certificates:
++
+[source,bash,options="nowrap"]
+----
+$ oc get secret elasticsearch-es-cert -o jsonpath='{.data.tls\.crt}' | base64 -d  | openssl x509 -in - -text | grep "Not After"
+            Not After : Mar  9 21:00:16 2026 GMT
+
+$ oc get secret  default-interconnect-selfsigned -o jsonpath='{.data.tls\.crt}' | base64 -d  | openssl x509 -in - -text | grep "Not After"
+            Not After : Mar  9 21:00:16 2033 GMT
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-tls-certificates-duration.adoc
@@ -2,23 +2,20 @@
 = Configuring TLS certificates duration
 
 [role="_abstract"]
-You can configure the duration of the TLS certificates to use with {Project} ({ProjectShort}) to fit your deployment needs.
-For this purpose, modify the `ServiceTelemetry` object and configure the `certificates` parameter.
+To configure the duration of the TLS certificates to use with {Project} ({ProjectShort}), modify the `ServiceTelemetry` object and configure the `certificates` parameter.
 
 .Prerequisites
 
-* Verify you don't have an instance of Service Telemetry Operator already deployed.
+* You didn't deploy an instance of Service Telemetry Operator already.
 
-NOTE:: Once created the `ServiceTelemetry` object, the required certificates and their secrets for {Project} ({ProjectShort}) are created.
-In order to modify these you must follow a procedure similar to the one present in xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
-The following procedure is valid for new {Project} ({ProjectShort}) deployments.
+NOTE:: When you create the `ServiceTelemetry` object, the required certificates and their secrets for {ProjectShort} are also created.
+For more information about how to modify the certificates and the secrets, see: xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
+The following procedure is valid for new {ProjectShort} deployments.
 
 .Procedure
 
-To override the duration of the TLS certificates, define which certificate you want to override.
-For example, set the Elasticsearch endpoint certificate duration to 3 years by setting `endpointCertDuration` to `26280h`
-and set QDR CA certificate duration to 10 years by setting `caCertDuration` to `87600h`.
-Keep the default value for the other certificates (CA certificate for Elasticsearch and endpoint certificate for QDR will keep the value of 8 years):
+To edit the duration of the TLS certificates, you can set the Elasticsearch `endpointCertDuration`, for example `26280h` for 3 years, and set the QDR `caCertDuration`, for example `87600h` for 10 years.
+You can use the default value of 8 years for the CA certificate for Elasticsearch and endpoint certificate:
 +
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----
@@ -45,7 +42,7 @@ EOF
 
 .Verification
 
-. Verify that the desired expiry date appears in the certificates:
+. Verify that the expiry date for the certificates is correct:
 +
 [source,bash,options="nowrap"]
 ----


### PR DESCRIPTION
Expose the duration value in STO to allow better control of the default certificate renewal times.