### PR TITLE
Adjust path to triple-ansible-inventory file

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_renewing-the-amq-interconnect-certificate.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_renewing-the-amq-interconnect-certificate.adoc
@@ -1,5 +1,5 @@
+ifdef::include_when_13,include_when_17[]
 ifdef::context[:parent-context: {context}]
-
 [id="assembly-renewing-the-amq-interconnect-certificate_{context}"]
 = Renewing the {MessageBus} certificate
 
@@ -18,3 +18,4 @@ include::../modules/proc_updating-the-amq-interconnect-ca-certificate.adoc[level
 //reset the context
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
+endif::include_when_13,include_when_17[]

--- a/doc-Service-Telemetry-Framework/modules/proc_updating-the-amq-interconnect-ca-certificate.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_updating-the-amq-interconnect-ca-certificate.adoc
@@ -25,26 +25,37 @@ $ oc get secret/default-interconnect-selfsigned -o jsonpath='{.data.ca\.crt}' | 
 . Log into your {OpenStackShort} undercloud.
 . Edit the `stf-connectors.yaml` file to contain the new caCertFileContent. For more information, see xref:configuring-the-stf-connection-for-the-overcloud_assembly-completing-the-stf-configuration[].
 
-. Copy the `STFCA.pem` file to each {OpenStackShort} overcloud node:
+ifdef::include_when_13[]
+. Generate an inventory file:
 +
 [source,bash,options="nowrap"]
 ----
+[stack@undercloud-0 ~]$ tripleo-ansible-inventory --static-yaml-inventory ./tripleo-ansible-inventory.yaml
+----
+endif::include_when_13[]
+
+. Copy the `STFCA.pem` file to each {OpenStackShort} overcloud node:
++
+[source,bash,options="nowrap"]
+ifdef::include_when_13[]
+----
+[stack@undercloud-0 ~]$ ansible -i tripleo-ansible-inventory.yaml allovercloud -b -m copy -a "src=STFCA.pem dest=/var/lib/config-data/puppet-generated/metrics_qdr/etc/pki/tls/certs/CA_sslProfile.pem"
+----
+endif::include_when_13[]
+ifdef::include_when_17[]
+----
 [stack@undercloud-0 ~]$ ansible -i overcloud-deploy/overcloud/tripleo-ansible-inventory.yaml allovercloud -b -m copy -a "src=STFCA.pem dest=/var/lib/config-data/puppet-generated/metrics_qdr/etc/pki/tls/certs/CA_sslProfile.pem"
 ----
+endif::include_when_17[]
+
 . Restart the metrics_qdr container on each {OpenStackShort} overcloud node:
 +
 [source,bash,options="nowrap"]
 ifdef::include_when_13[]
 ----
-[stack@undercloud-0 ~]$ tripleo-ansible-inventory --static-yaml-inventory ./tripleo-ansible-inventory.yaml
 [stack@undercloud-0 ~]$ ansible -i tripleo-ansible-inventory.yaml allovercloud -m shell -a "sudo podman restart metrics_qdr"
 ----
 endif::include_when_13[]
-ifdef::include_when_16+include_before_17[]
-----
-[stack@undercloud-0 ~]$ ansible -i tripleo-ansible-inventory.yaml allovercloud -m shell -a "sudo podman restart metrics_qdr"
-----
-endif::include_when_16+include_before_17[]
 ifdef::include_when_17[]
 ----
 [stack@undercloud-0 ~]$ ansible -i overcloud-deploy/overcloud/tripleo-ansible-inventory.yaml allovercloud -m shell -a "sudo podman restart metrics_qdr"


### PR DESCRIPTION
Adjust the path to the Ansible inventory file across RHOSP versions during documentation generation. Also fix inclusion of AMQ certificate renewal procedures in RHOSP 16 where certificate distribution does not exist.

Closes: rhbz#2158178
