### PR TITLE
Import changes for STF 1.5.1

### DIFF
--- a/build_tools/ci.sh
+++ b/build_tools/ci.sh
@@ -29,8 +29,8 @@ git config --global user.email "$GH_EMAIL" > /dev/null 2>&1
 git config --global user.name "$GH_NAME" > /dev/null 2>&1
 
 # Remove all files that are not in the .git dir
-echo "--- removing all files related to HEAD"
-find . -maxdepth 1 -not -wholename ".git/*" -not -wholename "./index-1-5-upstream*" -type f -delete
+echo "--- removing all files related to stable-1.5"
+find . -maxdepth 1 -not -wholename ".git/*" -type f -not -wholename "./index.html" -not -wholename "./index-upstream*" -delete
 rm -rf images/
 
 # We need this empty file for git not to try to build a jekyll project.

--- a/build_tools/ci.sh
+++ b/build_tools/ci.sh
@@ -29,8 +29,8 @@ git config --global user.email "$GH_EMAIL" > /dev/null 2>&1
 git config --global user.name "$GH_NAME" > /dev/null 2>&1
 
 # Remove all files that are not in the .git dir
-echo "--- removing all files related to stable-1.5"
-find . -maxdepth 1 -not -wholename ".git/*" -type f -not -wholename "./index.html" -not -wholename "./index-upstream*" -delete
+echo "--- removing all files related to HEAD"
+find . -maxdepth 1 -not -wholename ".git/*" -not -wholename "./index-1-5-upstream*" -type f -delete
 rm -rf images/
 
 # We need this empty file for git not to try to build a jekyll project.

--- a/common/global/stf-attributes.adoc
+++ b/common/global/stf-attributes.adoc
@@ -42,7 +42,7 @@ ifeval::["{build}" == "upstream"]
 :ProjectShort: STF
 :MessageBus: Apache{nbsp}Qpid{nbsp}Dispatch{nbsp}Router
 :SupportedOpenShiftVersion: 4.10
-:NextSupportedOpenShiftVersion: 4.10
+:NextSupportedOpenShiftVersion: 4.12
 :CodeReadyContainersVersion: 2.6.0
 endif::[]
 
@@ -60,5 +60,5 @@ ifeval::["{build}" == "downstream"]
 :ProjectShort: STF
 :MessageBus: AMQ{nbsp}Interconnect
 :SupportedOpenShiftVersion: 4.10
-:NextSupportedOpenShiftVersion: 4.10
+:NextSupportedOpenShiftVersion: 4.12
 endif::[]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
@@ -43,7 +43,14 @@ include::../modules/proc_creating-an-alert-route-in-alertmanager.adoc[leveloffse
 include::../modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc[leveloffset=+2]
 
 //SNMP Traps
-include::../modules/proc_configuring-snmp-traps.adoc[leveloffset=+1]
+include::../modules/con_snmp-traps.adoc[leveloffset=+1]
+include::../modules/proc_configuring-snmp-traps.adoc[leveloffset=+2]
+
+//TLS Certificates duration
+ifdef::include_when_13,include_when_17[]
+include::../modules/con_tls-certificates-duration.adoc[leveloffset=+1]
+include::../modules/proc_configuring-tls-certificates-duration.adoc[leveloffset=+2]
+endif::include_when_13,include_when_17[]
 
 //High availability
 include::../modules/con_high-availability.adoc[leveloffset=+1]
@@ -51,7 +58,9 @@ include::../modules/proc_configuring-high-availability.adoc[leveloffset=+2]
 
 //Configuring ephemeral storage
 include::../modules/con_ephemeral-storage.adoc[leveloffset=+1]
+ifeval::["{build}" == "upstream"]
 include::../modules/proc_configuring-ephemeral-storage.adoc[leveloffset=+2]
+endif::[]
 
 //Observability strategy
 include::../modules/con_observability-strategy.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_completing-the-stf-configuration.adoc
@@ -16,9 +16,8 @@ To collect metrics, events, or both, and to send them to the {Project} ({Project
 * To plan your {OpenStackShort} installation and configuration {ProjectShort} for multiple clouds, see xref:configuring-multiple-clouds_assembly-completing-the-stf-configuration[].
 
 * As part of an {OpenStackShort} overcloud deployment, you might need to configure additional features in your environment:
-
-** To deploy data collection and transport to {ProjectShort} on {OpenStackShort} cloud nodes that employ routed L3 domains, such as distributed compute node (DCN) or spine-leaf, see xref:deploying-to-non-standard-network-topologies_assembly-completing-the-stf-configuration[].
-
+// NOTE: removing this for now because it's not clear that this is necessary, and that recommendations here may actually be harmful. See RHBZ#2023902.
+//** To deploy data collection and transport to {ProjectShort} on {OpenStackShort} cloud nodes that employ routed L3 domains, such as distributed compute node (DCN) or spine-leaf, see xref:deploying-to-non-standard-network-topologies_assembly-completing-the-stf-configuration[].
 ** To disable the data collector services, see xref:disabling-openstack-services-used-with-stf_assembly-completing-the-stf-configuration[].
 
 ifdef::include_when_13[]
@@ -38,7 +37,8 @@ include::../modules/proc_validating-clientside-installation.adoc[leveloffset=+2]
 include::../modules/proc_disabling-openstack-services-used-with-stf.adoc[leveloffset=+1]
 
 // Gather information for deployment in non-standard network topologies in the OSP overcloud
-include::../modules/proc_deploying-to-non-standard-network-topologies.adoc[leveloffset=+1]
+// NOTE: removing this for now because it's not clear that this is necessary, and that recommendations here may actually be harmful. See RHBZ#2023902.
+//include::../modules/proc_deploying-to-non-standard-network-topologies.adoc[leveloffset=+1]
 
 ifdef::include_when_13[]
 // If you synchronized container images to a local registry, create an environment file and include the paths to the container images

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_renewing-the-amq-interconnect-certificate.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_renewing-the-amq-interconnect-certificate.adoc
@@ -1,5 +1,5 @@
+ifdef::include_when_13,include_when_17[]
 ifdef::context[:parent-context: {context}]
-
 [id="assembly-renewing-the-amq-interconnect-certificate_{context}"]
 = Renewing the {MessageBus} certificate
 
@@ -18,3 +18,4 @@ include::../modules/proc_updating-the-amq-interconnect-ca-certificate.adoc[level
 //reset the context
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
+endif::include_when_13,include_when_17[]

--- a/doc-Service-Telemetry-Framework/modules/con_dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_dashboards.adoc
@@ -19,7 +19,7 @@ Use the cloud view dashboard to view panels to monitor service resource usage, A
 ** For more information about {OpenStackShort} service monitoring, see xref:resource-usage-of-openstack-services_assembly-advanced-features[].
 
 Virtual machine view dashboard::
-Use the virtual machine view dashboard to view panels to monitor virtual machine infrastructure usage. Select a cloud and project from the upper left corner of the dashboard.
+Use the virtual machine view dashboard to view panels to monitor virtual machine infrastructure usage. Select a cloud and project from the upper left corner of the dashboard. You must enable event storage if you want to enable the event annotations on this dashboard. For more information, see xref:creating-a-servicetelemetry-object-in-openshift_assembly-installing-the-core-components-of-stf[].
 
 Memcached view dashboard::
 Use the memcached view dashboard to view panels to monitor connections, availability, system metrics and cache performance. Select a cloud from the upper left corner of the dashboard.

--- a/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
@@ -179,7 +179,7 @@ endif::[]
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
-  name: stf-default
+  name: default
   namespace: service-telemetry
 spec:
   clouds:

--- a/doc-Service-Telemetry-Framework/modules/con_snmp-traps.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_snmp-traps.adoc
@@ -1,0 +1,93 @@
+[id="snmp-traps_{context}"]
+= Sending alerts as SNMP traps
+
+[role="_abstract"]
+To enable SNMP traps, modify the `ServiceTelemetry` object and configure the `snmpTraps` parameters. SNMP traps are sent using version 2c.
+
+[id="configuration-parameters-for-snmptraps_{context}"]
+== Configuration parameters for snmpTraps
+
+The `snmpTraps` parameter contains the following sub-parameters for configuring the alert receiver:
+
+enabled:: Set the value of this sub-parameter to true to enable the SNMP trap alert receiver. The default value is false.
+target:: Target address to send SNMP traps. Value is a string. Default is `192.168.24.254`.
+port:: Target port to send SNMP traps. Value is an integer. Default is `162`.
+community:: Target community to send SNMP traps to. Value is a string. Default is `public`.
+retries:: SNMP trap retry delivery limit. Value is an integer. Default is `5`.
+timeout:: SNMP trap delivery timeout defined in seconds. Value is an integer. Default is `1`.
+alertOidLabel:: Label name in the alert that defines the OID value to send the SNMP trap as. Value is a string. Default is `oid`.
+trapOidPrefix:: SNMP trap OID prefix for variable bindings. Value is a string. Default is `1.3.6.1.4.1.50495.15`.
+trapDefaultOid:: SNMP trap OID when no alert OID label has been specified with the alert. Value is a string. Default is `1.3.6.1.4.1.50495.15.1.2.1`.
+trapDefaultSeverity:: SNMP trap severity when no alert severity has been set. Value is a string. Defaults to an empty string.
+
+Configure the `snmpTraps` parameter as part of the `alerting.alertmanager.receivers` definition in the `ServiceTelemetry` object:
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+  alerting:
+    alertmanager:
+      receivers:
+        snmpTraps:
+          alertOidLabel: oid
+          community: public
+          enabled: true
+          port: 162
+          retries: 5
+          target: 192.168.25.254
+          timeout: 1
+          trapDefaultOid: 1.3.6.1.4.1.50495.15.1.2.1
+          trapDefaultSeverity: ""
+          trapOidPrefix: 1.3.6.1.4.1.50495.15
+...
+----
+
+[id="overview-of-the-mib-definition_{context}"]
+== Overview of the MIB definition
+
+Delivery of SNMP traps uses object identifier (OID) value `1.3.6.1.4.1.50495.15.1.2.1` by default. The management information base (MIB) schema is available at https://github.com/infrawatch/prometheus-webhook-snmp/blob/master/PROMETHEUS-ALERT-CEPH-MIB.txt.
+
+The OID number is comprised of the following component values:
+* The value `1.3.6.1.4.1` is a global OID defined for private enterprises.
+* The next identifier `50495` is a private enterprise number assigned by IANA for the Ceph organization.
+* The other values are child OIDs of the parent.
+
+15:: prometheus objects
+15.1:: prometheus alerts
+15.1.2:: prometheus alert traps
+15.1.2.1:: prometheus alert trap default
+
+The prometheus alert trap default is an object comprised of several other sub-objects to OID `1.3.6.1.4.1.50495.15` which is defined by the `alerting.alertmanager.receivers.snmpTraps.trapOidPrefix` parameter:
+
+<trapOidPrefix>.1.1.1:: alert name
+<trapOidPrefix>.1.1.2:: status
+<trapOidPrefix>.1.1.3:: severity
+<trapOidPrefix>.1.1.4:: instance
+<trapOidPrefix>.1.1.5:: job
+<trapOidPrefix>.1.1.6:: description
+<trapOidPrefix>.1.1.7:: labels
+<trapOidPrefix>.1.1.8:: timestamp
+<trapOidPrefix>.1.1.9:: rawdata
+
+The following is example output from a simple SNMP trap receiver that outputs the received trap to the console:
+
+[source,options="nowrap"]
+----
+  SNMPv2-MIB::snmpTrapOID.0 = OID: SNMPv2-SMI::enterprises.50495.15.1.2.1
+  SNMPv2-SMI::enterprises.50495.15.1.1.1 = STRING: "TEST ALERT FROM PROMETHEUS PLEASE ACKNOWLEDGE"
+  SNMPv2-SMI::enterprises.50495.15.1.1.2 = STRING: "firing"
+  SNMPv2-SMI::enterprises.50495.15.1.1.3 = STRING: "warning"
+  SNMPv2-SMI::enterprises.50495.15.1.1.4 = ""
+  SNMPv2-SMI::enterprises.50495.15.1.1.5 = ""
+  SNMPv2-SMI::enterprises.50495.15.1.1.6 = STRING: "TEST ALERT FROM "
+  SNMPv2-SMI::enterprises.50495.15.1.1.7 = STRING: "{\"cluster\": \"TEST\", \"container\": \"sg-core\", \"endpoint\": \"prom-https\", \"prometheus\": \"service-telemetry/default\", \"service\": \"default-cloud1-coll-meter\", \"source\": \"SG\"}"
+  SNMPv2-SMI::enterprises.50495.15.1.1.8 = Timeticks: (1676476389) 194 days, 0:52:43.89
+  SNMPv2-SMI::enterprises.50495.15.1.1.9 = STRING: "{\"status\": \"firing\", \"labels\": {\"cluster\": \"TEST\", \"container\": \"sg-core\", \"endpoint\": \"prom-https\", \"prometheus\": \"service-telemetry/default\", \"service\": \"default-cloud1-coll-meter\", \"source\": \"SG\"}, \"annotations\": {\"action\": \"TESTING PLEASE ACKNOWLEDGE, NO FURTHER ACTION REQUIRED ONLY A TEST\"}, \"startsAt\": \"2023-02-15T15:53:09.109Z\", \"endsAt\": \"0001-01-01T00:00:00Z\", \"generatorURL\": \"http://prometheus-default-0:9090/graph?g0.expr=sg_total_collectd_msg_received_count+%3E+1&g0.tab=1\", \"fingerprint\": \"feefeb77c577a02f\"}"
+----
+
+

--- a/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_tls-certificates-duration.adoc
@@ -1,0 +1,65 @@
+[id="tls-certificates-duration_{context}"]
+= Configuring the duration for the TLS certificates
+
+[role="_abstract"]
+To configure the duration of the TLS certificates that you use for the connections with
+Elasticsearch and {MessageBus} in {Project} ({ProjectShort}),
+modify the `ServiceTelemetry` object and configure the `certificates` parameters.
+
+[id="configuration-parameters-for-tls-certificates-duration_{context}"]
+== Configuration parameters for the TLS certificates
+
+You can configure the duration of the certificate with the following sub-parameters of the `certificates` parameter:
+
+endpointCertDuration:: The requested 'duration' or lifetime of the endpoint Certificate.
+Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+The default value is `70080h`.
+caCertDuration:: The requested 'duration' or lifetime of the CA Certificate.
+Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+Default value is `70080h`.
+
+NOTE:: The default duration of certificates is long, because you usually copy a subset of them in the {OpenStack} deployment when the certificates renew. For more information about the QDR CA Certificate renewal process, see xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
+
+The `certificates` parameter for Elasticsearch is part of the `backends.events.elasticsearch` definition and is configured in the `ServiceTelemetry` object:
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+...
+  backends:
+    ...
+    events:
+      elasticsearch:
+        enabled: true
+        version: 7.16.1
+        certificates:
+          endpointCertDuration: 70080h
+          caCertDuration: 70080h
+...
+----
+
+You can configure the `certificates` parameter for QDR that is part of the `transports.qdr` definition in the `ServiceTelemetry` object:
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+...
+  transports:
+    ...
+    qdr:
+      enabled: true
+      certificates:
+        endpointCertDuration: 70080h
+        caCertDuration: 70080h
+...
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-ephemeral-storage.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-ephemeral-storage.adoc
@@ -28,7 +28,7 @@ $ oc edit stf default
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
-  name: stf-default
+  name: default
   namespace: service-telemetry
 spec:
   alerting:

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-observability-strategy.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-observability-strategy.adoc
@@ -23,6 +23,13 @@ spec:
 EOF
 ----
 +
+. Delete the left over objects that are managed by community operators
++
+[source,bash]
+----
+$ for o in alertmanager/default prometheus/default elasticsearch/elasticsearch grafana/default lokistack/lokistack; do oc delete $o; done
+----
++
 . To verify that all workloads are operating correctly, view the pods and the status of each pod:
 +
 [source,bash,options="nowrap"]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -17,5 +17,5 @@ endif::include_when_13,include_when_17[]
 
 ifdef::include_when_16_1[]
 .Additional resources
-* To collect data through {MessageBus}, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{vernum}/html/operational_measurements/collectd-plugins_assembly[the amqp1 plug-in].
+* To collect data through {MessageBus}, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{vernum}/html/operational_measurements/collectd-plugins_assembly#collectd_plugin_amqp1[the amqp1 plug-in].
 endif::include_when_16_1[]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-snmp-traps.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-snmp-traps.adoc
@@ -2,16 +2,20 @@
 [id="configuring-snmp-traps_{context}"]
 = Configuring SNMP traps
 
-[role="_abstract"]
-You can integrate {Project} ({ProjectShort}) with an existing infrastructure monitoring platform that receives notifications through SNMP traps. To enable SNMP traps, modify the `ServiceTelemetry` object and configure the `snmpTraps` parameters.
-
-For more information about configuring alerts, see xref:alerts_assembly-advanced-features[].
-
 .Prerequisites
 
-* Know the IP address or hostname of the SNMP trap receiver where you want to send the alerts
+* Ensure that you know the IP address or hostname of the SNMP trap receiver where you want to send the alerts to.
 
 .Procedure
+
+. Log in to {OpenShift}.
+
+. Change to the `service-telemetry` namespace:
++
+[source,bash]
+----
+$ oc project service-telemetry
+----
 
 . To enable SNMP traps, modify the `ServiceTelemetry` object:
 +
@@ -19,6 +23,7 @@ For more information about configuring alerts, see xref:alerts_assembly-advanced
 ----
 $ oc edit stf default
 ----
+
 . Set the `alerting.alertmanager.receivers.snmpTraps` parameters:
 +
 [source,yaml]
@@ -37,3 +42,55 @@ spec:
 ----
 
 . Ensure that you set the value of `target` to the IP address or hostname of the SNMP trap receiver.
+
+.Additional Information
+
+For more information about available parameters for `snmpTraps`, see xref:configuration-parameters-for-snmptraps_assembly-advanced-features[].
+
+[id="creating-alerts-for-snmp-traps_{context}"]
+= Creating alerts for SNMP traps
+
+You can create alerts that are configured for delivery by SNMP traps by adding labels that are parsed by the prometheus-webhook-snmp middleware to define the trap information and delivered object identifiers (OID). Adding the `oid` or `severity` labels is only required if you need to change the default values for a particular alert definition.
+
+NOTE:: When you set the oid label, the top-level SNMP trap OID changes, but the sub-OIDs remain defined by the global `trapOidPrefix` value plus the child OID values `.1.1.1` through `.1.1.9`. For more information about the MIB definition, see xref:overview-of-the-mib-definition_{context}[].
+
+.Procedure
+
+. Log in to {OpenShift}.
+
+. Change to the `service-telemetry` namespace:
++
+[source,bash]
+----
+$ oc project service-telemetry
+----
+
+. Create a `PrometheusRule` object that contains the alert rule and an `oid` label that contains the SNMP trap OID override value:
++
+[source,bash]
+----
+$ oc apply -f - <<EOF
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    prometheus: default
+    role: alert-rules
+  name: prometheus-alarm-rules-snmp
+  namespace: service-telemetry
+spec:
+  groups:
+    - name: ./openstack.rules
+      rules:
+        - alert: Collectd metrics receive rate is zero
+          expr: rate(sg_total_collectd_msg_received_count[1m]) == 0
+          labels:
+            oid: 1.3.6.1.4.1.50495.15.1.2.1
+            severity: critical
+EOF
+----
+
+.Additional information
+
+For more information about configuring alerts, see xref:alerts_assembly-advanced-features[].

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -47,7 +47,7 @@ resource_registry:
 
 parameter_defaults:
     MetricsQdrConnectors:
-        - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch
+        - host: default-interconnect-5671-service-telemetry.apps.infra.watch
           port: 443
           role: edge
           verifyHostname: false

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-tls-certificates-duration.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-tls-certificates-duration.adoc
@@ -1,0 +1,54 @@
+[id="configuring-tls-certificates-duration_{context}"]
+= Configuring TLS certificates duration
+
+[role="_abstract"]
+To configure the duration of the TLS certificates to use with {Project} ({ProjectShort}), modify the `ServiceTelemetry` object and configure the `certificates` parameter.
+
+.Prerequisites
+
+* You didn't deploy an instance of Service Telemetry Operator already.
+
+NOTE:: When you create the `ServiceTelemetry` object, the required certificates and their secrets for {ProjectShort} are also created.
+For more information about how to modify the certificates and the secrets, see: xref:assembly-renewing-the-amq-interconnect-certificate_assembly[]
+The following procedure is valid for new {ProjectShort} deployments.
+
+.Procedure
+
+To edit the duration of the TLS certificates, you can set the Elasticsearch `endpointCertDuration`, for example `26280h` for 3 years, and set the QDR `caCertDuration`, for example `87600h` for 10 years.
+You can use the default value of 8 years for the CA certificate for Elasticsearch and endpoint certificate:
++
+[source,yaml,options="nowrap",role="white-space-pre"]
+----
+$ oc apply -f - <<EOF
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+metadata:
+  name: default
+  namespace: service-telemetry
+spec:
+  backends:
+    events:
+      elasticsearch:
+        enabled: true
+        certificates:
+          endpointCertDuration: 26280h
+  transport:
+    qdr:
+      enabled: true
+      certificates:
+        caCertDuration: 87600h
+EOF
+----
+
+.Verification
+
+. Verify that the expiry date for the certificates is correct:
++
+[source,bash,options="nowrap"]
+----
+$ oc get secret elasticsearch-es-cert -o jsonpath='{.data.tls\.crt}' | base64 -d  | openssl x509 -in - -text | grep "Not After"
+            Not After : Mar  9 21:00:16 2026 GMT
+
+$ oc get secret  default-interconnect-selfsigned -o jsonpath='{.data.tls\.crt}' | base64 -d  | openssl x509 -in - -text | grep "Not After"
+            Not After : Mar  9 21:00:16 2033 GMT
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
@@ -21,10 +21,10 @@ alertmanager.yaml: |-
   - name: 'null'
 ----
 
-To deploy a custom Alertmanager route with {ProjectShort}, you must pass an `alertmanagerConfigManifest` parameter to the Service Telemetry Operator that results in an updated secret, managed by the Prometheus Operator.
+To deploy a custom Alertmanager route with {ProjectShort}, you must add a `alertmanagerConfigManifest` parameter to the Service Telemetry Operator that results in an updated secret, managed by the Prometheus Operator.
 
 [NOTE]
-If your `alertmanagerConfigManifest` contains a custom template to construct the title and text of the sent alert, deploy the contents of the `alertmanagerConfigManifest` using a base64-encoded configuration. For more information, see xref:creating-an-alert-route-with-templating-in-alertmanager_assembly-advanced-features[].
+If your `alertmanagerConfigManifest` contains a custom template, for example, to construct the title and text of the sent alert, you must deploy the contents of the `alertmanagerConfigManifest` using a base64-encoded configuration. For more information, see xref:creating-an-alert-route-with-templating-in-alertmanager_assembly-advanced-features[].
 
 .Procedure
 
@@ -102,11 +102,11 @@ receivers:
 ----
 
 
-. Run the `curl` command against the `alertmanager-proxy` service to retrieve the status and `configYAML` contents, and verify that the supplied configuration matches the configuration in Alertmanager:
+. Run the `wget` command from the prometheus pod against the `alertmanager-proxy` service to retrieve the status and `configYAML` contents, and verify that the supplied configuration matches the configuration in Alertmanager:
 +
 [source,bash,options="nowrap"]
 ----
-$ oc run curl -it --serviceaccount=prometheus-k8s --restart='Never' --image=radial/busyboxplus:curl -- sh -c "curl -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer \$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://default-alertmanager-proxy:9095/api/v1/status"
+$ oc exec -it prometheus-default-0 -c prometheus -- sh -c "wget --header \"Authorization: Bearer \$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://default-alertmanager-proxy:9095/api/v1/status -q -O -"
 
 {"status":"success","data":{"configYAML":"...",...}}
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-with-templating-in-alertmanager.adoc
@@ -22,7 +22,7 @@ alertmanager.yaml: |-
   - name: 'null'
 ----
 
-If the `alertmanagerConfigManifest` parameter contains a custom template, for example, to construct the title and text of the sent alert, deploy the contents of the `alertmanagerConfigManifest` by using a base64-encoded configuration.
+If the `alertmanagerConfigManifest` parameter contains a custom template, for example, to construct the title and text of the sent alert, you must deploy the contents of the `alertmanagerConfigManifest` by using a base64-encoded configuration.
 
 .Procedure
 
@@ -36,39 +36,41 @@ If the `alertmanagerConfigManifest` parameter contains a custom template, for ex
 $ oc project service-telemetry
 ----
 
-. Edit the `ServiceTelemetry` object for your {ProjectShort} deployment:
+. Create the necessary alertmanager config in a file called alertmanager.yaml, for example:
 +
-[source,bash]
+[source,yaml]
 ----
-$ oc edit stf default
+$ cat > alertmanager.yaml <<EOF
+global:
+  resolve_timeout: 10m
+  slack_api_url: <slack_api_url>
+receivers:
+  - name: slack
+    slack_configs:
+    - channel: #stf-alerts
+      title: |-
+        ...
+      text: >-
+        ...
+route:
+  group_by: ['job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: 'slack'
+EOF
 ----
-
-. To deploy a custom Alertmanager route with {ProjectShort}, you must pass an `alertmanagerConfigManifest` parameter to the Service Telemetry Operator that results in an updated secret that is managed by the Prometheus Operator:
+. Generate the config manifest and add it to the `ServiceTelemetry` object for your {ProjectShort} deployment:
 +
-[source,yaml,options="nowrap"]
+[source,bash,options="nowrap"]
 ----
-apiVersion: infra.watch/v1beta1
-kind: ServiceTelemetry
-metadata:
-  name: default
-  namespace: service-telemetry
-spec:
-  backends:
-    metrics:
-      prometheus:
-        enabled: true
-  alertmanagerConfigManifest: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: 'alertmanager-default'
-      namespace: 'service-telemetry'
-    type: Opaque
-    data:
-      alertmanager.yaml: Z2xvYmFsOgogIHJlc29sdmVfdGltZW91dDogMTBtCiAgc2xhY2tfYXBpX3VybDogPHNsYWNrX2FwaV91cmw+CnJlY2VpdmVyczoKICAtIG5hbWU6IHNsYWNrCiAgICBzbGFja19jb25maWdzOgogICAgLSBjaGFubmVsOiAjc3RmLWFsZXJ0cwogICAgICB0aXRsZTogfC0KICAgICAgICAuLi4KICAgICAgdGV4dDogPi0KICAgICAgICAuLi4Kcm91dGU6CiAgZ3JvdXBfYnk6IFsnam9iJ10KICBncm91cF93YWl0OiAzMHMKICBncm91cF9pbnRlcnZhbDogNW0KICByZXBlYXRfaW50ZXJ2YWw6IDEyaAogIHJlY2VpdmVyOiAnc2xhY2snCg==
+$ CONFIG_MANIFEST=$(oc create secret --dry-run=client generic alertmanager-default --from-file=alertmanager.yaml -o json)
+$ oc patch stf default --type=merge -p '{"spec":{"alertmanagerConfigManifest":'"$CONFIG_MANIFEST"'}}'
 ----
-
 . Verify that the configuration has been applied to the secret:
++
+[NOTE]
+There will be a short delay as the operators update each object
 +
 [source,bash,options="nowrap"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -74,7 +74,7 @@ resource_registry:
 
 parameter_defaults:
     MetricsQdrConnectors:
-        - host: stf-default-interconnect-5671-service-telemetry.apps.infra.watch
+        - host: default-interconnect-5671-service-telemetry.apps.infra.watch
           port: 443
           role: edge
           verifyHostname: false

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -55,7 +55,8 @@ parameter_defaults:
         - image.*
         - memory
         - memory.*
-        - network.*
+        - network.services.vpn.*
+        - network.services.firewall.*
         - perf.*
         - port
         - port.*
@@ -138,7 +139,8 @@ parameter_defaults:
         - image.*
         - memory
         - memory.*
-        - network.*
+        - network.services.vpn.*
+        - network.services.firewall.*
         - perf.*
         - port
         - port.*

--- a/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_editing-the-metrics-retention-time-period-in-service-telemetry-framework.adoc
@@ -33,7 +33,7 @@ If you set a long retention period, retrieving data from heavily populated Prome
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
 metadata:
-  name: stf-default
+  name: default
   namespace: service-telemetry
 spec:
   ...
@@ -48,6 +48,19 @@ spec:
 ----
 
 . Save your changes and close the object.
+. Wait for prometheus to restart with the new settings.
++
+[source,bash]
+----
+$ oc get po -l app.kubernetes.io/name=prometheus -w
+----
+. Verify the new retention setting by checking the command line arguments used in the pod.
++
+[source,bash]
+----
+$ oc describe po prometheus-default-0 | grep retention.time
+      --storage.tsdb.retention.time=24h
+----
 
 .Additional resources
 

--- a/doc-Service-Telemetry-Framework/modules/proc_retrieving-and-setting-grafana-login-credentials.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_retrieving-and-setting-grafana-login-credentials.adoc
@@ -2,7 +2,9 @@
 = Retrieving and setting Grafana login credentials
 
 [role="_abstract"]
-{Project} ({ProjectShort}) sets default login credentials when Grafana is enabled. You can override the credentials in the `ServiceTelemetry` object.
+When Grafana is enabled, you can login using openshift authentication, or the default username and password set by the Grafana Operator.
+
+You can override the credentials in the `ServiceTelemetry` object to have {Project} ({ProjectShort}) set the username and password for Grafana instead.
 
 .Procedure
 
@@ -13,7 +15,7 @@
 ----
 $ oc project service-telemetry
 ----
-. Retrieve the default username and password from the {ProjectShort} object:
+. Retrieve the existing username and password from the {ProjectShort} object:
 +
 [source,bash]
 ----
@@ -21,3 +23,14 @@ $ oc get stf default -o jsonpath="{.spec.graphing.grafana['adminUser','adminPass
 ----
 
 . To modify the default values of the Grafana administrator username and password through the ServiceTelemetry object, use the `graphing.grafana.adminUser` and `graphing.grafana.adminPassword` parameters.
++
+[source,bash]
+----
+$ oc edit stf default
+----
+. Wait for the grafana pod to restart with the new credentials in place
++
+[source,bash]
+----
+$ oc get po -l app=grafana -w
+----

--- a/doc-Service-Telemetry-Framework/modules/proc_updating-the-amq-interconnect-ca-certificate.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_updating-the-amq-interconnect-ca-certificate.adoc
@@ -25,19 +25,35 @@ $ oc get secret/default-interconnect-selfsigned -o jsonpath='{.data.ca\.crt}' | 
 . Log into your {OpenStackShort} undercloud.
 . Edit the `stf-connectors.yaml` file to contain the new caCertFileContent. For more information, see xref:configuring-the-stf-connection-for-the-overcloud_assembly-completing-the-stf-configuration[].
 
-. Copy the `STFCA.pem` file to each {OpenStackShort} overcloud node:
+ifdef::include_when_13[]
+. Generate an inventory file:
 +
 [source,bash,options="nowrap"]
 ----
+[stack@undercloud-0 ~]$ tripleo-ansible-inventory --static-yaml-inventory ./tripleo-ansible-inventory.yaml
+----
+endif::include_when_13[]
+
+. Copy the `STFCA.pem` file to each {OpenStackShort} overcloud node:
++
+[source,bash,options="nowrap"]
+ifdef::include_when_13[]
+----
+[stack@undercloud-0 ~]$ ansible -i tripleo-ansible-inventory.yaml overcloud -b -m copy -a "src=STFCA.pem dest=/var/lib/config-data/puppet-generated/metrics_qdr/etc/pki/tls/certs/CA_sslProfile.pem"
+----
+endif::include_when_13[]
+ifdef::include_when_17[]
+----
 [stack@undercloud-0 ~]$ ansible -i overcloud-deploy/overcloud/tripleo-ansible-inventory.yaml allovercloud -b -m copy -a "src=STFCA.pem dest=/var/lib/config-data/puppet-generated/metrics_qdr/etc/pki/tls/certs/CA_sslProfile.pem"
 ----
+endif::include_when_17[]
+
 . Restart the metrics_qdr container on each {OpenStackShort} overcloud node:
 +
 [source,bash,options="nowrap"]
 ifdef::include_when_13[]
 ----
-[stack@undercloud-0 ~]$ tripleo-ansible-inventory --static-yaml-inventory ./tripleo-ansible-inventory.yaml
-[stack@undercloud-0 ~]$ ansible -i tripleo-ansible-inventory.yaml allovercloud -m shell -a "sudo podman restart metrics_qdr"
+[stack@undercloud-0 ~]$ ansible -i tripleo-ansible-inventory.yaml overcloud -m shell -a "sudo {containerbin} restart metrics_qdr"
 ----
 endif::include_when_13[]
 ifdef::include_when_16+include_before_17[]

--- a/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_validating-clientside-installation.adoc
@@ -10,15 +10,26 @@ TIP: Some telemetry data is available only when {OpenStackShort} has active work
 
 . Log in to an overcloud node, for example, controller-0.
 
-. Ensure that the `metrics_qdr` container is running on the node:
+. Ensure that the `metrics_qdr` and collection agent containers are running on the node:
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr
-
+$ sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr collectd ceilometer_agent_notification ceilometer_agent_central
+running
+running
+running
 running
 ----
-
++
+[NOTE]
+====
+Use this command on compute nodes:
+[source,bash,options="nowrap",subs="attributes"]
+-----
+$ sudo {containerbin} container inspect --format '{{.State.Status}}' metrics_qdr collectd ceilometer_agent_compute
+-----
+====
++
 . Return the internal network address on which {MessageBus} is running, for example, `172.17.1.44` listening on port `5666`:
 +
 [source,bash,options="nowrap",subs="attributes"]


### PR DESCRIPTION
- Add procedure to disable services on OSP side (#407)
- Don't remove existing 'stable-1.5' generated files (#412)
- Minor updates to dashboarding guide (#413)
- Fix syntax error in certificate renewal module (#416)
- Removed sending-metrics-to-gnocchi-and-to-stf m… (#414)
- Jof mas minor edits 1.5 (#421)
- Update link to STF life cycle page (#423)
- updated link (#428)
- Updated path to match PR#52 in dashboard repo (#427)
- Fixed alertmanager verification command (#430)
- Eliminate mentions of sensubility in OSP13 (#431)
- A list of low hanging docs changes from our feature testing (#426)
- mg_master_2161659_minor-style-edit changed note text and position (#437)
- Remove note from importing dashboards procedure (#439)
- Adjust network polling meter for ceilometer (#440)
- Eliminate vestiges of "stf-default" (#442)
- Link to the amqp1 plugin header directly (#443)
- Bump base image for building to Fedora 37 (#445)
- mg_master_2168184_adding section with procedures for upgrade from 1.4… (#444)
- Fix alertmanager verification command
- Revert "Fix alertmanager verification command"
- Fix alertmanager verification command (#450)
- Reference event enablement for virtual machine view (#451)
- Expand supported OCP range through to 4.12 (#452)
- Adjust path to triple-ansible-inventory file (#454)
- Remove DCN related configuration artifacts (#455)
- Add SNMP trap configuration parameters (#449)
- Expose ability to set certificate renewal target times (#453)
- [OSP13] Replacing "allovercloud" with "overcloud" in ansible command (#456)
- [OSP13] Replacing podman with docker in ansible command. (#457)
