### PR TITLE
Fix issues with links

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -16,7 +16,7 @@ endif::include_when_13,include_when_17[]
 . xref:validating-clientside-installation_assembly-completing-the-stf-configuration[Validating client-side installation]
 
 .Additional resources
-* For more information about deploying an OpenStack cloud using director, see link:{defaultURL}/html/director_installation_and_usage/index
+* For more information about deploying an OpenStack cloud using director, see link:{defaultURL}/director_installation_and_usage/index[Director Installation and Usage].
 ifdef::include_when_16_1[]
-* To collect data through {MessageBus}, see link:{defaultURL}/html/operational_measurements/collectd-plugins_assembly#collectd_plugin_amqp1[the amqp1 plug-in].
+* To collect data through {MessageBus}, see link:{defaultURL}/operational_measurements/collectd-plugins_assembly#collectd_plugin_amqp1[the amqp1 plug-in].
 endif::include_when_16_1[]


### PR DESCRIPTION
Fix issues with links in the documentation. Invalid use of extra /html
path in the URL and syntax error in the asciidoc link syntax.

Closes: rhbz#2209734
