### PR TITLE
Remove reference to lokistack

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-observability-strategy.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-observability-strategy.adoc
@@ -27,7 +27,7 @@ EOF
 +
 [source,bash]
 ----
-$ for o in alertmanager/default prometheus/default elasticsearch/elasticsearch grafana/default lokistack/lokistack; do oc delete $o; done
+$ for o in alertmanager/default prometheus/default elasticsearch/elasticsearch grafana/default; do oc delete $o; done
 ----
 +
 . To verify that all workloads are operating correctly, view the pods and the status of each pod:


### PR DESCRIPTION
Remove reference to lokistack when removing objects because deployments
done via documentation would never have Loki enabled (development only).

Closes: rhbz#2189674
