### PR TITLE
Clarify topic configuration in stf-connectors.yaml

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_primary-parameters-of-the-servicetelemetry-object.adoc
@@ -187,20 +187,20 @@ spec:
       metrics:
         collectors:
           - collectorType: collectd
-            subscriptionAddress: collectd/telemetry
+            subscriptionAddress: collectd/cloud1-telemetry
           - collectorType: ceilometer
-            subscriptionAddress: anycast/ceilometer/metering.sample
+            subscriptionAddress: anycast/ceilometer/cloud1-metering.sample
 ifndef::include_when_13[]
           - collectorType: sensubility
-            subscriptionAddress: sensubility/telemetry
+            subscriptionAddress: sensubility/cloud1-telemetry
             debugEnabled: false
 endif::[]
       events:
         collectors:
           - collectorType: collectd
-            subscriptionAddress: collectd/notify
+            subscriptionAddress: collectd/cloud1-notify
           - collectorType: ceilometer
-            subscriptionAddress: anycast/ceilometer/event.sample
+            subscriptionAddress: anycast/ceilometer/cloud1-event.sample
 ----
 
 ifndef::include_when_13[]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -86,7 +86,7 @@ endif::[]
 
 [NOTE]
 ====
-When defining the topics for collectd and Ceilometer, the value provided is transposed into the full topic that the Smart Gateway client will listen for messages.
+When you define the topics for collectd and Ceilometer, the value you provide is transposed into the full topic that the Smart Gateway client uses to listen for messages.
 
 Ceilometer topic values are transposed into the topic address `anycast/ceilometer/<TOPIC>.sample` and collectd topic values are transposed into the topic address `collectd/<TOPIC>`.
 ifndef::include_when_13[The value for sensubility is the full topic path and has no transposition from topic value to topic address.]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -91,5 +91,5 @@ When you define the topics for collectd and Ceilometer, the value you provide is
 Ceilometer topic values are transposed into the topic address `anycast/ceilometer/<TOPIC>.sample` and collectd topic values are transposed into the topic address `collectd/<TOPIC>`.
 ifndef::include_when_13[The value for sensubility is the full topic path and has no transposition from topic value to topic address.]
 
-For an example that shows a cloud configuration in the `ServiceTelemetry` object referring to the full topic address, see xref:clouds_assembly-installing-the-core-components-of-stf[].
+For an example of a cloud configuration in the `ServiceTelemetry` object referring to the full topic address, see xref:clouds_assembly-installing-the-core-components-of-stf[].
 ====

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -76,10 +76,20 @@ ifdef::include_when_13,include_when_17[]
 * Replace the `caCertFileContent` parameter with the contents retrieved in xref:getting-ca-certificate-from-stf-for-overcloud-configuration_assembly-completing-the-stf-configuration[].
 endif::include_when_13,include_when_17[]
 * Replace the `host` sub-parameter of `MetricsQdrConnectors` with the value that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
-* Set `CeilometerQdrEventsConfig.topic` to define the topic for Ceilometer events. The format of this value is `anycast/ceilometer/cloud1-event.sample`.
-* Set `CeilometerQdrMetricsConfig.topic` to define the topic for Ceilometer metrics. The format of this value is `anycast/ceilometer/cloud1-metering.sample`.
-* Set `CollectdAmqpInstances` to define the topic for collectd events. The format of this value is `collectd/cloud1-notify`.
-* Set `CollectdAmqpInstances` to define the topic for collectd metrics. The format of this value is `collectd/cloud1-telemetry`.
+* Set `topic` value of `CeilometerQdrEventsConfig` to define the topic for Ceilometer events. The value is a unique topic idenifier for the cloud such as `cloud1-event`.
+* Set `topic` value of `CeilometerQdrMetricsConfig.topic` to define the topic for Ceilometer metrics. The value is a unique topic identifier for the cloud such as `cloud1-metering`.
+* Set `CollectdAmqpInstances` sub-paramter to define the topic for collectd events. The section name is a unique topic identifier for the cloud such as `cloud1-notify`.
+* Set `CollectdAmqpInstances` sub-parameter to define the topic for collectd metrics. The section name is a unique topic identifier for the cloud such as `cloud1-telemetry`.
 ifndef::include_when_13[]
-* Set `CollectdSensubilityResultsChannel` to define the topic for collectd-sensubility events. The format of this value is `sensubility/cloud1-telemetry`.
+* Set `CollectdSensubilityResultsChannel` to define the topic for collectd-sensubility events. The value is a unique topic identifier for the cloud such as `sensubility/cloud1-telemetry`.
 endif::[]
+
+[NOTE]
+====
+When defining the topics for collectd and Ceilometer, the value provided is transposed into the full topic that the Smart Gateway client will listen for messages.
+
+Ceilometer topic values are transposed into the topic address `anycast/ceilometer/<TOPIC>.sample` and collectd topic values are transposed into the topic address `collectd/<TOPIC>`.
+ifndef::include_when_13[The value for sensubility is the full topic path and has no transposition from topic value to topic address.]
+
+For an example that shows a cloud configuration in the `ServiceTelemetry` object referring to the full topic address, see xref:clouds_assembly-installing-the-core-components-of-stf[].
+====

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -115,7 +115,7 @@ endif::[]
 +
 [NOTE]
 ====
-When defining the topics for collectd and Ceilometer, the value provided is transposed into the full topic that the Smart Gateway client will listen for messages.
+When you define the topics for collectd and Ceilometer, the value you provide is transposed into the full topic that the Smart Gateway client uses to listen for messages.
 
 Ceilometer topic values are transposed into the topic address `anycast/ceilometer/<TOPIC>.sample` and collectd topic values are transposed into the topic address `collectd/<TOPIC>`.
 ifndef::include_when_13[The value for sensubility is the full topic path and has no transposition from topic value to topic address.]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -98,19 +98,30 @@ ifndef::include_when_13[]
     CollectdSensubilityResultsChannel: sensubility/cloud1-telemetry
 endif::[]
 ----
-
++
 * The `resource_registry` configuration directly loads the collectd service because you do not include the `collectd-write-qdr.yaml` environment file for multiple cloud deployments.
+* Replace the `host` parameter with the value that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
 ifdef::include_when_13,include_when_17[]
-* Replace the `MetricsQdrConnectors.host` parameter with the value that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
 * Replace the `caCertFileContent` parameter with the contents retrieved in xref:getting-ca-certificate-from-stf-for-overcloud-configuration_assembly-completing-the-stf-configuration[].
 endif::include_when_13,include_when_17[]
-* Set the `CeilometerQdrEventsConfig.topic` to define the topic for Ceilometer events. This value is the address format of `anycast/ceilometer/cloud1-event.sample`.
-* Set the `CeilometerQdrMetricsConfig.topic` to define the topic for Ceilometer metrics. This value is the address format of `anycast/ceilometer/cloud1-metering.sample`.
-* Set the `CollectdAmqpInstances` to define the topic for collectd events. This value is the format of `collectd/cloud1-notify`.
-* Set the `CollectdAmqpInstances` to define the topic for collectd metrics. This value is the format of `collectd/cloud1-telemetry`.
+* Replace the `host` sub-parameter of `MetricsQdrConnectors` with the value that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
+* Set `topic` value of `CeilometerQdrEventsConfig` to define the topic for Ceilometer events. The value is a unique topic idenifier for the cloud such as `cloud1-event`.
+* Set `topic` value of `CeilometerQdrMetricsConfig.topic` to define the topic for Ceilometer metrics. The value is a unique topic identifier for the cloud such as `cloud1-metering`.
+* Set `CollectdAmqpInstances` sub-paramter to define the topic for collectd events. The section name is a unique topic identifier for the cloud such as `cloud1-notify`.
+* Set `CollectdAmqpInstances` sub-parameter to define the topic for collectd metrics. The section name is a unique topic identifier for the cloud such as `cloud1-telemetry`.
 ifndef::include_when_13[]
-* Set the `CollectdSensubilityResultsChannel` to define the topic for collectd-sensubility events. This value is the format of `sensubility/cloud1-telemetry`
+* Set `CollectdSensubilityResultsChannel` to define the topic for collectd-sensubility events. The value is a unique topic identifier for the cloud such as `sensubility/cloud1-telemetry`.
 endif::[]
++
+[NOTE]
+====
+When defining the topics for collectd and Ceilometer, the value provided is transposed into the full topic that the Smart Gateway client will listen for messages.
+
+Ceilometer topic values are transposed into the topic address `anycast/ceilometer/<TOPIC>.sample` and collectd topic values are transposed into the topic address `collectd/<TOPIC>`.
+ifndef::include_when_13[The value for sensubility is the full topic path and has no transposition from topic value to topic address.]
+
+For an example that shows a cloud configuration in the `ServiceTelemetry` object referring to the full topic address, see xref:clouds_assembly-installing-the-core-components-of-stf[].
+====
 
 . Ensure that the naming convention in the `stf-connectors.yaml` file aligns with the `spec.bridge.amqpUrl` field in the Smart Gateway configuration. For example, configure the `CeilometerQdrEventsConfig.topic` field to a value of `cloud1-event`.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -120,7 +120,7 @@ When defining the topics for collectd and Ceilometer, the value provided is tran
 Ceilometer topic values are transposed into the topic address `anycast/ceilometer/<TOPIC>.sample` and collectd topic values are transposed into the topic address `collectd/<TOPIC>`.
 ifndef::include_when_13[The value for sensubility is the full topic path and has no transposition from topic value to topic address.]
 
-For an example that shows a cloud configuration in the `ServiceTelemetry` object referring to the full topic address, see xref:clouds_assembly-installing-the-core-components-of-stf[].
+For an example of a cloud configuration in the `ServiceTelemetry` object referring to the full topic address, see xref:clouds_assembly-installing-the-core-components-of-stf[].
 ====
 
 . Ensure that the naming convention in the `stf-connectors.yaml` file aligns with the `spec.bridge.amqpUrl` field in the Smart Gateway configuration. For example, configure the `CeilometerQdrEventsConfig.topic` field to a value of `cloud1-event`.


### PR DESCRIPTION
Clarify the topic configuration in stf-connectors.yaml so the
administrator knows there is an underlying transposition happening where
the topic value is transposed into a topic address, and this is the full
address that would be referenced by the Smart Gateway configuration via
ServiceTelemetry object, clouds parameter.

Add a note that helps with understanding how the value is transposed
from the provided value into the full topic address listened on the bus.

Also clarify the difference between the Ceilometer configuration which
as a sub-parameter called topic, and the collectd configuration that has
a unique parameter name to identify the topic value.

Link back to an exaple configuration to make it clear how the value is
transposed into the full address. Update the linked clouds section to
match our unique-cloud configuration through the document.

Closes: rhbz#2189678
Closes: rhbz#2189677
