### PR TITLE
Make OpenStack log in procedures consistent

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -14,7 +14,7 @@ endif::include_when_13,include_when_17[]
 // The following configuration should match the contents in modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc. If you have changes to make, please make the same changes to both files.
 .Procedure
 
-. Log in to the {OpenStackShort} undercloud as the `stack` user.
+. Log in to the undercloud host as the `stack` user.
 
 . Create a configuration file called `stf-connectors.yaml` in the `/home/stack` directory.
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -41,7 +41,7 @@ ifdef::include_when_13,include_when_17[* You have retrieved the CA certificate f
 
 .Procedure
 
-. Log in to the {OpenStack} undercloud as the `stack` user.
+. Log in to the undercloud host as the `stack` user.
 
 . Create a configuration file called `stf-connectors.yaml` in the `/home/stack` directory.
 
@@ -125,13 +125,13 @@ For an example of a cloud configuration in the `ServiceTelemetry` object referri
 
 . Ensure that the naming convention in the `stf-connectors.yaml` file aligns with the `spec.bridge.amqpUrl` field in the Smart Gateway configuration. For example, configure the `CeilometerQdrEventsConfig.topic` field to a value of `cloud1-event`.
 
-. Source the authentication file:
+. Log in to the undercloud host as the `stack` user.
+
+. Source the `stackrc` undercloud credentials file:
 +
 [source,bash]
 ----
-[stack@undercloud-0 ~]$ source stackrc
-
-(undercloud) [stack@undercloud-0 ~]$
+$ source stackrc
 ----
 
 . Include the `stf-connectors.yaml` file and unique domain name environment file `hostnames.yaml` in the `openstack overcloud deployment` command, with any other environment files relevant to your environment:
@@ -139,20 +139,15 @@ For an example of a cloud configuration in the `ServiceTelemetry` object referri
 [WARNING]
 If you use the `collectd-write-qdr.yaml` file with a custom `CollectdAmqpInstances` parameter, data publishes to the custom and default topics. In a multiple cloud environment, the configuration of the `resource_registry` parameter in the `stf-connectors.yaml` file loads the collectd service.
 +
-// valid use of +quotes subs for rendering emphasis
-
-+
-[source,bash,options="nowrap",subs="+quotes"]
-
+[source,bash,options="nowrap"]
 ----
-(undercloud) [stack@undercloud-0 ~]$ openstack overcloud deploy _<other_arguments>_
---templates /usr/share/openstack-tripleo-heat-templates \
-  --environment-file _<...other_environment_files...>_ \
-  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
-  --environment-file /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml \
-  --environment-file /home/stack/hostnames.yaml \
-  --environment-file /home/stack/enable-stf.yaml \
-  --environment-file /home/stack/stf-connectors.yaml
+(undercloud)$ openstack overcloud deploy --templates \
+-e [your environment files] \
+-e /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml \
+-e /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml \
+-e /home/stack/hostnames.yaml \
+-e /home/stack/enable-stf.yaml \
+-e /home/stack/stf-connectors.yaml
 ----
 
 . Deploy the {OpenStack} overcloud.

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -6,7 +6,7 @@ To configure the base parameters to provide a compatible data collection and tra
 
 .Procedure
 
-. Log in to the {OpenStack} ({OpenStackShort}) undercloud as the `stack` user.
+. Log in to the undercloud host as the `stack` user.
 
 . Create a configuration file called `enable-stf.yaml` in the `/home/stack` directory.
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud.adoc
@@ -6,15 +6,13 @@ Deploy or update the overcloud with the required environment files so that data 
 
 .Procedure
 
-. Log in to the {OpenStack} ({OpenStackShort}) undercloud as the `stack` user.
+. Log in to the undercloud host as the `stack` user.
 
-. Source the authentication file:
+. Source the `stackrc` undercloud credentials file:
 +
 [source,bash]
 ----
-[stack@undercloud-0 ~]$ source stackrc
-
-(undercloud) [stack@undercloud-0 ~]$
+$ source ~/stackrc
 ----
 
 . Add your data collection and {MessageBus} environment files to the stack with your other environment files and deploy the overcloud:

--- a/doc-Service-Telemetry-Framework/modules/proc_disabling-openstack-services-used-with-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_disabling-openstack-services-used-with-stf.adoc
@@ -6,22 +6,20 @@ Disable the services used when deploying {OpenStack} ({OpenStackShort}) and conn
 
 .Procedure
 
-. Log in to the {OpenStackShort} undercloud as the `stack` user.
+. Log in to the undercloud host as the `stack` user.
 
-. Source the authentication file:
+. Source the `stackrc` undercloud credentials file:
 +
 [source,bash]
 ----
-[stack@undercloud-0 ~]$ source stackrc
-
-(undercloud) [stack@undercloud-0 ~]$
+$ source ~/stackrc
 ----
 
 . Create the `disable-stf.yaml` environment file:
 +
 [source,yaml,options="nowrap"]
 ----
-(undercloud) [stack@undercloud-0]$ cat > $HOME/disable-stf.yaml <<EOF
+$ cat > ~/disable-stf.yaml <<EOF
 ---
 resource_registry:
   OS::TripleO::Services::CeilometerAgentCentral: OS::Heat::None
@@ -43,12 +41,9 @@ EOF
 
 . Update the {OpenStackShort} overcloud. Ensure that you use the `disable-stf.yaml` file early in the list of environment files. By adding `disable-stf.yaml` early in the list, other environment files can override the configuration that would disable the service:
 +
-// this one is actually a valid use of subs +quotes. We want the underbars to result in emphasis when generated.
-+
-[source,bash,options="nowrap",subs="+quotes"]
+[source,bash,options="nowrap"]
 ----
-(undercloud) [stack@undercloud-0 ~]$ openstack overcloud deploy _<other_arguments>_
---templates /usr/share/openstack-tripleo-heat-templates \
-  --environment-file /home/stack/disable-stf.yaml
-  --environment-file _<other_environment_files>_ \
+(undercloud)$ openstack overcloud deploy --templates \
+-e /home/stack/disable-stf.yaml \
+-e [your environment files]
 ----


### PR DESCRIPTION
Update the OpenStack log in procedures for consistency with the RHOSP style guide.
