### PR TITLE
Refer to AMQ Interconnect version more loosely

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-to-the-openshift-environment.adoc
@@ -151,7 +151,7 @@ spec:
 EOF
 ----
 
-. Validate your ClusterServiceVersion. Ensure that amq7-interconnect-operator.v1.10.10 displays a phase of `Succeeded`:
+. Validate your ClusterServiceVersion. Ensure that amq7-interconnect-operator.v1.10.x displays a phase of `Succeeded`:
 +
 [source,bash,options="nowrap",role="white-space-pre"]
 ----


### PR DESCRIPTION
Instead of referring to the AMQ Interconnect Operator version
specifically, make the reference a bit more loose to avoid having to
keep output and procedure steps in sync.
