### PR TITLE
Clarify which OCP to get the AMQ route from

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_retrieving-the-qdr-route-address.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_retrieving-the-qdr-route-address.adoc
@@ -6,9 +6,16 @@ When you configure the {OpenStack} ({OpenStackShort}) overcloud for {Project} ({
 
 .Procedure
 
-. Log in to your {OpenShift} environment.
+. Log in to your {OpenShift} environment where {ProjectShort} is hosted.
 
-. In the `service-telemetry` project, retrieve the {MessageBus} route address:
+. Change to the `service-telemetry` project:
++
+[source,bash]
+----
+$ oc project service-telemetry
+----
+
+. Retrieve the {MessageBus} route address:
 +
 [source,bash,options="nowrap",subs="verbatim"]
 ----


### PR DESCRIPTION
Due to reusable content, it's not clear which OCP environment to get the
AMQ Interconnect route from. Update the documentation to clarify that
you're logging into the OCP cluster hosting STF.

Also make the step about changing to service-telemetry project more
consistent to match other documentation.

Closes: rhbz#2212954
