### PR TITLE
Clarify some ambiguity with which OCP to login to

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-director-operator-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-director-operator-for-the-overcloud.adoc
@@ -7,7 +7,12 @@ Edit the `heat-env-config-deploy` ConfigMap to create a connection from {OpenSta
 
 .Procedure
 
-. Login to the {OpenShift} environment and change to the project that hosts your {OpenStack} deployment.
+. Login to the {OpenShift} environment where {OpenStackShort} director Operator is deployed and change to the project that hosts your {OpenStackShort} deployment:
++
+[source,bash]
+----
+oc project openstack
+----
 
 . Open the `heat-env-config-deploy` ConfigMap for editing:
 +
@@ -63,4 +68,4 @@ data:
 .Additional resources
 * For more information about the `stf-connectors.yaml` environment file, see xref:configuring-the-stf-connection-for-the-overcloud_assembly-completing-the-stf-configuration[].
 
-* For more information about adding heat templates to a {OpenStack} director Operator deployment, see link:{defaultURL}/rhosp_director_operator_for_openshift_container_platform/assembly_adding-heat-templates-and-environment-files-with-the-director-operator_rhosp-director-operator#doc-wrapper[Adding heat templates and environment files with the director Operator]
+* For more information about adding heat templates to a {OpenStackShort} director Operator deployment, see link:{defaultURL}/rhosp_director_operator_for_openshift_container_platform/assembly_adding-heat-templates-and-environment-files-with-the-director-operator_rhosp-director-operator#doc-wrapper[Adding heat templates and environment files with the director Operator]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
@@ -7,7 +7,12 @@ Edit the `heat-env-config-deploy` ConfigMap to add the base {Project} ({ProjectS
 
 .Procedure
 
-. Login to your {OpenShift} environment and change to the project that hosts your {OpenStack} ({OpenStackShort}) deployment.
+. Login to the {OpenShift} environment where {OpenStackShort} director Operator is deployed and change to the project that hosts your {OpenStackShort} deployment:
++
+[source,bash]
+----
+oc project openstack
+----
 
 . Open the `heat-env-config-deploy` ConfigMap for editing:
 +

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud-for-director-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud-for-director-operator.adoc
@@ -7,7 +7,12 @@ Deploy or update the overcloud with the required environment files so that data 
 
 .Procedure
 
-. Login to your {OpenShift} environment and change to the project that hosts your {OpenStack} ({OpenStackShort}) deployment.
+. Login to the {OpenShift} environment where {OpenStackShort} director Operator is deployed and change to the project that hosts your {OpenStackShort} deployment:
++
+[source,bash]
+----
+oc project openstack
+----
 
 . Open the `OpenStackConfigGenerator` custom resource for editing:
 +
@@ -19,7 +24,6 @@ $ oc edit OpenStackConfigGenerator
 . Add the `metrics/ceilometer-write-qdr.yaml` and `metrics/qdr-edge-only.yaml` environment files as values for the `heatEnvs` parameter. Save your edits, and close the `OpenStackConfigGenerator` custom resource:
 [NOTE]
 If you already deployed a {OpenStack} environment using director Operator, you must delete the existing `OpenStackConfigGenerator` and create a new object with the full configuration in order to re-generate the `OpenStackConfigVersion`.
-
 +
 .OpenStackConfigGenerator
 [source,yaml,options="nowrap"]


### PR DESCRIPTION
Update documentation to clarify which OCP cluster the administrator
should login to, and which project to load.

Closes: rhbz#2212957
