### PR TITLE
Fix xrefs for director Operator (#481)

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf-using-director-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf-using-director-operator.adoc
@@ -15,9 +15,9 @@ When you deploy the {OpenStack} ({OpenStackShort}) overcloud deployment using di
 //endif::include_when_13,include_when_17[]
 
 . xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[Retrieving the {MessageBus} route address]
-. xref:proc_creating-the-base-configuration-for-director-operator-for-stf[Creating the base configuration for director Operator for {ProjectShort}]
-. xref:proc_configuring-the-stf-connection-for-director-operator-for-the-overcloud[Configuring the {ProjectShort} connection for the overcloud]
-. xref:proc_deploying-the-overcloud-for-director-operator[Deploying the overcloud for director operator]
+. xref:creating-the-base-configuration-for-director-operator-for-stf_assembly-completing-the-stf-configuration-using-director-operator[Creating the base configuration for director Operator for {ProjectShort}]
+. xref:configuring-the-stf-connection-for-director-operator-for-the-overcloud_assembly-completing-the-stf-configuration-using-director-operator[Configuring the {ProjectShort} connection for the overcloud]
+. xref:deploying-the-overcloud-for-director-operator_assembly-completing-the-stf-configuration-using-director-operator[Deploying the overcloud for director operator]
 
 //. xref:validating-clientside-installation_assembly-completing-the-stf-configuration[Validating client-side installation]
 


### PR DESCRIPTION
Fix the xrefs for the director Operator. The xrefs were referring to the
filename instead of the id+assembly value.

(cherry picked from commit 87686b015bbf61e286e4d376a18bcff4c4e90709)
