### PR TITLE
Override qdr::router_id defaults in stf-connectors

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -32,6 +32,9 @@ resource_registry:
   OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml
 
 parameter_defaults:
+    ExtraConfig:
+        qdr::router_id: "%{::hostname}.cloud1"
+
     MetricsQdrConnectors:
         - host: default-interconnect-5671-service-telemetry.apps.infra.watch
           port: 443
@@ -70,6 +73,7 @@ ifndef::include_when_13[]
 endif::[]
 ----
 
+* The `qdr::router_id` configuration is to override the default value which uses the fully-qualified domain name (FQDN) of the host. In some cases the FQDN can result in a router ID length of greater than 61 characters which results in failed QDR connections. For deployments with shorter FQDN values this is not necessary.
 * The `resource_registry` configuration directly loads the collectd service because you do not include the `collectd-write-qdr.yaml` environment file for multiple cloud deployments.
 * Replace the `host` parameter with the value that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
 ifdef::include_when_13,include_when_17[]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-openstack-environment-file-for-multiple-clouds.adoc
@@ -61,6 +61,9 @@ resource_registry:
   OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml
 
 parameter_defaults:
+    ExtraConfig:
+        qdr::router_id: %{::hostname}.cloud1
+
     MetricsQdrConnectors:
         - host: default-interconnect-5671-service-telemetry.apps.infra.watch
           port: 443
@@ -99,6 +102,7 @@ ifndef::include_when_13[]
 endif::[]
 ----
 +
+* The `qdr::router_id` configuration is to override the default value which uses the fully-qualified domain name (FQDN) of the host. In some cases the FQDN can result in a router ID length of greater than 61 characters which results in failed QDR connections. For deployments with shorter FQDN values this is not necessary.
 * The `resource_registry` configuration directly loads the collectd service because you do not include the `collectd-write-qdr.yaml` environment file for multiple cloud deployments.
 * Replace the `host` parameter with the value that you retrieved in xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[].
 ifdef::include_when_13,include_when_17[]


### PR DESCRIPTION
Update the documentation to provide an override to the FQDN in the
qdr::router_id configuration to avoid hostnames longer than 61 chars.

Closes rhbz#2208020
