### PR TITLE
Adjust the default polling interval for collectd

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
@@ -51,8 +51,8 @@ data:
         # set collectd overrides for higher telemetry resolution and extra plugins
         # to load
         CollectdConnectionType: amqp1
-        CollectdAmqpInterval: 5
-        CollectdDefaultPollingInterval: 5
+        CollectdAmqpInterval: 30
+        CollectdDefaultPollingInterval: 30
         CollectdExtraPlugins:
         - vmem
 

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -32,8 +32,8 @@ parameter_defaults:
 
     # set collectd overrides for higher telemetry resolution and extra plugins to load
     CollectdConnectionType: amqp1
-    CollectdAmqpInterval: 5
-    CollectdDefaultPollingInterval: 5
+    CollectdAmqpInterval: 30
+    CollectdDefaultPollingInterval: 30
     CollectdExtraPlugins:
     - vmem
 
@@ -114,8 +114,8 @@ parameter_defaults:
     # set collectd overrides for higher telemetry resolution and extra plugins
     # to load
     CollectdConnectionType: amqp1
-    CollectdAmqpInterval: 5
-    CollectdDefaultPollingInterval: 5
+    CollectdAmqpInterval: 30
+    CollectdDefaultPollingInterval: 30
     CollectdExtraPlugins:
     - vmem
 


### PR DESCRIPTION
Adjust the collectd polling interval to be 30 seconds instead of 5
seconds.

Related STF-1512

Implemented by https://github.com/infrawatch/service-telemetry-operator/pull/454