### PR TITLE
Reduce the number of Ceilometer pollsters

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
@@ -67,19 +67,7 @@ data:
            ceilometer::agent::polling::polling_interval: 30
            ceilometer::agent::polling::polling_meters:
            - cpu
-           - disk.*
-           - ip.*
-           - image.*
-           - memory
-           - memory.*
-           - network.*
-           - perf.*
-           - port
-           - port.*
-           - switch
-           - switch.*
-           - storage.*
-           - volume.*
+           - memory.usage
 
            # to avoid filling the memory buffers if disconnected from the message bus
            # note: this may need an adjustment if there are many metrics to be sent.

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -48,20 +48,7 @@ parameter_defaults:
         ceilometer::agent::polling::polling_interval: 30
         ceilometer::agent::polling::polling_meters:
         - cpu
-        - disk.*
-        - ip.*
-        - image.*
-        - memory
-        - memory.*
-        - network.services.vpn.*
-        - network.services.firewall.*
-        - perf.*
-        - port
-        - port.*
-        - switch
-        - switch.*
-        - storage.*
-        - volume.*
+        - memory.usage
 
         # to avoid filling the memory buffers if disconnected from the message bus
         # note: Adjust the value of the `send_queue_limit` to handle your required volume of metrics.
@@ -130,20 +117,7 @@ parameter_defaults:
         ceilometer::agent::polling::polling_interval: 30
         ceilometer::agent::polling::polling_meters:
         - cpu
-        - disk.*
-        - ip.*
-        - image.*
-        - memory
-        - memory.*
-        - network.services.vpn.*
-        - network.services.firewall.*
-        - perf.*
-        - port
-        - port.*
-        - switch
-        - switch.*
-        - storage.*
-        - volume.*
+        - memory.usage
 
         # to avoid filling the memory buffers if disconnected from the message bus
         # note: this may need an adjustment if there are many metrics to be sent.


### PR DESCRIPTION
Reduce the number of Ceilometer pollsters to only those used by the
sample STF dashboards.

Closes: rhbz#2239390
