### PR TITLE
Do not manage the event pipeline by default

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
@@ -37,6 +37,7 @@ data:
         # manage the polling and pipeline configuration files for Ceilometer agents
         ManagePolling: true
         ManagePipeline: true
+        ManageEventPipeline: false
 
         # enable Ceilometer metrics and events
         CeilometerQdrPublishMetrics: true

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -26,6 +26,7 @@ parameter_defaults:
     # manage the polling and pipeline configuration files for Ceilometer agents
     ManagePolling: true
     ManagePipeline: true
+    ManageEventPipeline: false
 
     # enable Ceilometer metrics
     CeilometerQdrPublishMetrics: true
@@ -87,6 +88,7 @@ parameter_defaults:
     # manage the polling and pipeline configuration files for Ceilometer agents
     ManagePolling: true
     ManagePipeline: true
+    ManageEventPipeline: false
 
     # enable Ceilometer metrics
     CeilometerQdrPublishMetrics: true


### PR DESCRIPTION
We do not want events to be sent to QDR by default, as the STF 1.5.3
default configuration will deploy telemetry only

Related STF-1498
