### PR TITLE
Creating an alert does not use curl

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-route-in-alertmanager.adoc
@@ -113,15 +113,6 @@ $ oc exec -it prometheus-default-0 -c prometheus -- sh -c "wget --header \"Autho
 
 . Verify that the `configYAML` field contains the changes you expect.
 
-. To clean up the environment, delete the `curl` pod:
-+
-[source,bash]
-----
-$ oc delete pod curl
-
-pod "curl" deleted
-----
-
 .Additional resources
 
 * For more information about the {OpenShift} secret and the Prometheus operator, see https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md[Prometheus user guide on alerting].


### PR DESCRIPTION
The Creating a standard alert route in Alertmanager section no longer
uses curl to verify the configuration was loaded, since it uses the
prometheus pod and the wget command instance. Removes an extra procedure
step that is no longer applicable.
