### PR TITLE
Summary: Replace incorrect stf-connectors.yaml filename 

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -18,7 +18,7 @@ grafanadashboard.integreatly.org/rhos-dashboard-1 created
 . Import the cloud dashboard:
 +
 [WARNING]
-In the `stf-connectors.yaml` file, ensure you set the value of the collectd `virt` plugin parameter `hostname_format` to `name uuid hostname`, otherwise some of the panels on the cloud dashboard display no information. For more information about the `virt` plugin, see link:{defaultURL}/operational_measurements/collectd-plugins_assembly[collectd plugins].
+In the `enable-stf.yaml` file, ensure you set the value of the collectd `virt` plugin parameter `hostname_format` to `name uuid hostname`, otherwise some of the panels on the cloud dashboard display no information. For more information about the `virt` plugin, see link:{defaultURL}/operational_measurements/collectd-plugins_assembly[collectd plugins].
 +
 [source,bash,options="nowrap"]
 ----


### PR DESCRIPTION
Replaced with enable-stf.yaml

Tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2239871

Branch: master-BZ-2239871