### PR TITLE
Fix various RHOSP links and versions

### DIFF
--- a/common/global/rhosp_attributes.adoc
+++ b/common/global/rhosp_attributes.adoc
@@ -15,7 +15,7 @@
 
 :osp_long: Red Hat OpenStack Platform
 :osp_acro: RHOSP
-:osp_curr_ver: 17.1-Beta
+:osp_curr_ver: 17.1
 :osp_curr_ver_no_beta: 17.1
 :osp_z_stream: 0
 
@@ -29,5 +29,6 @@
 :defaultURL: https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{osp_curr_ver}/html
 :defaultCephURL:  https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/{CephVernum}/html
 
-:setup-tlse: {defaultURL}/hardening_red_hat_openstack_platform/assembly_securing-rhos-with-tls-and-pki_security_and_hardening#proc_implementing-tls-e-with-ansible_encryption-and-key-management[Implementing TLS-e with Ansible]
+// Specific links
 
+:setup-tlse: {defaultURL}/hardening_red_hat_openstack_platform/assembly_securing-rhos-with-tls-and-pki_security_and_hardening#proc_implementing-tls-e-with-ansible_encryption-and-key-management[Implementing TLS-e with Ansible]

--- a/common/global/stf-attributes.adoc
+++ b/common/global/stf-attributes.adoc
@@ -28,6 +28,10 @@ ifeval::[{vernum} >= 17.0]
 :include_when_17:
 endif::[]
 
+ifeval::[{vernum} == 17.1]
+:include_when_17_1:
+endif::[]
+
 ifeval::[{ProductVersion} < 1.5]
 :include_before_stf15:
 endif::[]
@@ -47,7 +51,7 @@ ifeval::["{build}" == "upstream"]
 :MessageBus: Apache{nbsp}Qpid{nbsp}Dispatch{nbsp}Router
 :SupportedOpenShiftVersion: 4.12
 :NextSupportedOpenShiftVersion: 4.14
-:CodeReadyContainersVersion: 2.6.0
+:CodeReadyContainersVersion: 2.19.0
 endif::[]
 
 ifeval::["{build}" == "downstream"]

--- a/doc-Service-Telemetry-Framework/master.adoc
+++ b/doc-Service-Telemetry-Framework/master.adoc
@@ -1,7 +1,7 @@
 = Service Telemetry Framework 1.5
 OpenStack Documentation Team <rhos-docs@redhat.com>
 :imagesdir: images
-:vernum: 17.0
+:vernum: 17.1
 :toc: left
 :toclevels: 3
 :icons: font
@@ -32,9 +32,9 @@ include::assemblies/assembly_installing-the-core-components-of-stf.adoc[leveloff
 include::assemblies/assembly_completing-the-stf-configuration.adoc[leveloffset=+1]
 
 ifeval::["{build}" == "downstream"]
-ifdef::include_when_16_2[]
+ifdef::include_when_16_2,include_when_17_1[]
 include::assemblies/assembly_completing-the-stf-configuration-using-director-operator.adoc[leveloffset=+1]
-endif::include_when_16_2[]
+endif::include_when_16_2,include_when_17_1[]
 endif::[]
 
 //advanced features
@@ -46,7 +46,7 @@ include::assemblies/assembly_renewing-the-amq-interconnect-certificate.adoc[leve
 // removing
 include::assemblies/assembly_removing-stf-from-the-openshift-environment.adoc[leveloffset=+1]
 
-//collectd plugins
-
 // upgrading to 1.5
-include::assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-5.adoc[leveloffset=+1]
+// NOTE: this is no longer being rendered because the expectation is to move from STF 1.4 on OCP 4.8 to STF 1.5 on OCP 4.10, both of which are EOL now.
+// if this affects you, please open a customer case to help manage the upgrade, or simply perform a greenfield deployment of STF 1.5 on OCP 4.14.
+//include::assemblies/assembly_upgrading-service-telemetry-framework-to-version-1-5.adoc[leveloffset=+1]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf-using-director-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf-using-director-operator.adoc
@@ -10,9 +10,9 @@ When you deploy the {OpenStack} ({OpenStackShort}) overcloud deployment using di
 .Procedure
 
 // NOTE: not required until available for RHOSP 17.1
-//ifdef::include_when_13,include_when_17[]
-//. xref:getting-ca-certificate-from-stf-for-overcloud-configuration_assembly-completing-the-stf-configuration[]
-//endif::include_when_13,include_when_17[]
+ifdef::include_when_13,include_when_17[]
+. xref:getting-ca-certificate-from-stf-for-overcloud-configuration_assembly-completing-the-stf-configuration[]
+endif::include_when_13,include_when_17[]
 
 . xref:retrieving-the-qdr-route-address_assembly-completing-the-stf-configuration[Retrieving the {MessageBus} route address]
 . xref:creating-the-base-configuration-for-director-operator-for-stf_assembly-completing-the-stf-configuration-using-director-operator[Creating the base configuration for director Operator for {ProjectShort}]
@@ -23,7 +23,11 @@ When you deploy the {OpenStack} ({OpenStackShort}) overcloud deployment using di
 
 
 .Additional resources
-* For more information about deploying an OpenStack cloud using director Operator, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{vernum}/html/rhosp_director_operator_for_openshift_container_platform/index
-ifdef::include_when_16_1[]
-* To collect data through {MessageBus}, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{vernum}/html/operational_measurements/collectd-plugins_assembly#collectd_plugin_amqp1[the amqp1 plug-in].
-endif::include_when_16_1[]
+ifdef::include_when_16_2[]
+* For more information about deploying an OpenStack cloud using director Operator, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.2/html/rhosp_director_operator_for_openshift_container_platform/index
+* To collect data through {MessageBus}, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.2/html/operational_measurements/collectd-plugins_assembly#collectd_plugin_amqp1[the amqp1 plug-in].
+endif::[]
+ifdef::include_when_17_1[]
+* For more information about deploying an OpenStack cloud using director Operator, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/17.1/html/deploying_an_overcloud_in_a_red_hat_openshift_container_platform_cluster_with_director_operator/index
+* To collect data through {MessageBus}, see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/17.1/html/managing_overcloud_observability/collectd-plugins_assembly#collectd_plugin_amqp1[the amqp1 plug-in].
+endif::[]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-red-hat-openstack-platform-overcloud-for-stf.adoc
@@ -17,7 +17,11 @@ endif::include_when_13,include_when_17[]
 . xref:validating-clientside-installation_assembly-completing-the-stf-configuration[Validating client-side installation]
 
 .Additional resources
+ifdef::include_when_16_2[]
 * For more information about deploying an OpenStack cloud using director, see link:{defaultURL}/director_installation_and_usage/index[Director Installation and Usage].
-ifdef::include_when_16_1[]
 * To collect data through {MessageBus}, see link:{defaultURL}/operational_measurements/collectd-plugins_assembly#collectd_plugin_amqp1[the amqp1 plug-in].
-endif::include_when_16_1[]
+endif::[]
+ifdef::include_when_17_1[]
+* For more information about deploying an OpenStack cloud using director, see link:{defaultURL}/installing_and_managing_red_hat_openstack_platform_with_director/index[Installing and managing Red Hat OpenStack Platform with director].
+* To collect data through {MessageBus}, see link:{defaultURL}/managing_overcloud_observability/collectd-plugins_assembly#collectd_plugin_amqp1[the amqp1 plug-in].
+endif::[]


### PR DESCRIPTION
Fix various links to RHOSP documentation as the paths are different between RHOSP 16.2 and 17.1. Guides were updated but there is no auto-redirect, so we'll need to verify every link that uses defaultURL parameter. This covers the initial ones while working through documentation.

Update some older version links and add a new parameter for 17.1 paths specifically.
