### PR TITLE
Update deprecated Grafana login warning

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_retrieving-and-setting-grafana-login-credentials.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_retrieving-and-setting-grafana-login-credentials.adoc
@@ -6,7 +6,7 @@ When Grafana is enabled, you can login using OpenShift authentication, or the de
 
 [WARNING]
 ====
-Logging in using the default username and password set by the Grafana Operator is deprecated. Use the _Log in with OpenShift_ button to access the dashboards.
+Ensure that you log in to access the dashboards with the _Log in with OpenShift_ button, because the default username and password set by the Grafana Operator is deprecated.
 ====
 
 You can override the credentials in the `ServiceTelemetry` object to have {Project} ({ProjectShort}) set the username and password for Grafana instead.


### PR DESCRIPTION
Update the Grafana login deprecation warning with wording from the
documentation team.
