### PR TITLE
Set infrawatch-operators to highest priority

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_enabling-infrawatch-catalog-source.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_enabling-infrawatch-catalog-source.adoc
@@ -46,6 +46,7 @@ spec:
   image: quay.io/infrawatch-operators/infrawatch-catalog:nightly
   publisher: InfraWatch
   sourceType: grpc
+  priority: -200
   updateStrategy:
     registryPoll:
       interval: 30m


### PR DESCRIPTION
Set the priority to -200 to make the infrawatch-operators CatalogSource
a higher priority than redhat-operators CatalogSource.

Setting the priority to highest values means the dependency resolution
will resolve Smart Gateway Operator (SGO) out of the
infrawatch-operators CatalogSource instead of from the redhat-operators
CatalogSource, which could result in failed deployments if there are
changes in SGO required within Service Telemetry Operator.
