### PR TITLE
Refer to cert-manager removal documentation

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_removing-stf-from-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_removing-stf-from-the-openshift-environment.adoc
@@ -20,7 +20,9 @@ include::../modules/proc_deleting-the-namespace.adoc[leveloffset=+1]
 ifeval::["{build}" == "upstream"]
 include::../modules/proc_removing-the-catalogsource.adoc[leveloffset=+1]
 endif::[]
-include::../modules/proc_removing-the-cert-manager-operator.adoc[leveloffset=+1]
+include::../modules/ref_removing-the-cert-manager-operator.adoc[leveloffset=+1]
+//include::../modules/proc_removing-the-cert-manager-operator.adoc[leveloffset=+1]
+
 
 //reset the context
 ifdef::parent-context[:context: {parent-context}]

--- a/doc-Service-Telemetry-Framework/modules/ref_removing-the-cert-manager-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/ref_removing-the-cert-manager-operator.adoc
@@ -22,12 +22,13 @@
 // _Wording of headings_ in _The IBM Style Guide_.
 
 [id="removing-the-cert-manager-operator_{context}"]
-= Removing the cert-manager Operator
+= Removing the cert-manager Operator for Red Hat OpenShift
 
 [role="_abstract"]
-If you are not using the cert-manager Operator for any other applications, delete the Subscription, ClusterServiceVersion, and CustomResourceDefinitions.
+If you are not using the cert-manager Operator for Red Hat OpenShift for any other applications, delete the Subscription, ClusterServiceVersion, and CustomResourceDefinitions.
+
+For more information about removing the cert-manager for Red Hat OpenShift Operator, see link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/security/cert_manager_operator/cert-manager-operator-uninstall.html[Removing cert-manager Operator for Red Hat OpenShift] in the _OpenShift Container Platform Documentation_.
 
 .Additional resources
 
-* link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/security/cert_manager_operator/cert-manager-operator-uninstall.html[Removing cert-manager Operator for Red Hat OpenShift].
 * link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/operators/admin/olm-deleting-operators-from-cluster.html[Deleting Operators from a cluster].

--- a/doc-Service-Telemetry-Framework/modules/ref_removing-the-cert-manager-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/ref_removing-the-cert-manager-operator.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+// This module can be included from assemblies using the following include statement:
+// include::<path>/proc_removing-the-cert-manager-operator.adoc[leveloffset=+1]
+
+// The file name and the ID are based on the module title. For example:
+// * file name: proc_doing-procedure-a.adoc
+// * ID: [id='proc_doing-procedure-a_{context}']
+// * Title: = Doing procedure A
+//
+// The ID is used as an anchor for linking to the module. Avoid changing
+// it after the module has been published to ensure existing links are not
+// broken.
+//
+// The `context` attribute enables module reuse. Every module's ID includes
+// {context}, which ensures that the module has a unique ID even if it is
+// reused multiple times in a guide.
+//
+// Start the title with a verb, such as Creating or Create. See also
+// _Wording of headings_ in _The IBM Style Guide_.
+
+[id="removing-the-cert-manager-operator_{context}"]
+= Removing the cert-manager Operator
+
+[role="_abstract"]
+If you are not using the cert-manager Operator for any other applications, delete the Subscription, ClusterServiceVersion, and CustomResourceDefinitions.
+
+.Additional resources
+
+* link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/security/cert_manager_operator/cert-manager-operator-uninstall.html[Removing cert-manager Operator for Red Hat OpenShift].
+* link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/operators/admin/olm-deleting-operators-from-cluster.html[Deleting Operators from a cluster].


### PR DESCRIPTION
Update the STF removal guide to refer to the cert-manager uninstallation
procedure which is maintained by that team.

Closes: STF-1642
