### PR TITLE
Add removal instructions for COO

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_removing-stf-from-the-openshift-environment.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_removing-stf-from-the-openshift-environment.adoc
@@ -15,12 +15,14 @@ ifeval::["{build}" == "upstream"]
 . Remove the catalog source.
 endif::[]
 . Remove the cert-manager Operator.
+. Remove the {ObservabilityOperator}.
 
 include::../modules/proc_deleting-the-namespace.adoc[leveloffset=+1]
 ifeval::["{build}" == "upstream"]
 include::../modules/proc_removing-the-catalogsource.adoc[leveloffset=+1]
 endif::[]
 include::../modules/proc_removing-the-cert-manager-operator.adoc[leveloffset=+1]
+include::../modules/ref_removing-the-observability-operator.adoc[leveloffset=+1]
 
 //reset the context
 ifdef::parent-context[:context: {parent-context}]

--- a/doc-Service-Telemetry-Framework/modules/ref_removing-the-observability-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/ref_removing-the-observability-operator.adoc
@@ -27,7 +27,8 @@
 [role="_abstract"]
 If you are not using the {ObservabilityOperator} for any other applications, delete the Subscription, ClusterServiceVersion, and CustomResourceDefinitions.
 
+For more information about removing the {ObservabilityOperator}, see link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/monitoring/cluster_observability_operator/installing-the-cluster-observability-operator.html#uninstalling-the-cluster-observability-operator-using-the-web-console_installing_the_cluster_observability_operator[Uninstalling the Cluster Observability Operator using the web console] in the _OpenShift Container Platform Documentation_.
+
 .Additional resources
 
-* link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/monitoring/cluster_observability_operator/installing-the-cluster-observability-operator.html#uninstalling-the-cluster-observability-operator-using-the-web-console_installing_the_cluster_observability_operator[Uninstalling the Cluster Observability Operator using the web console].
 * link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/operators/admin/olm-deleting-operators-from-cluster.html[Deleting Operators from a cluster].

--- a/doc-Service-Telemetry-Framework/modules/ref_removing-the-observability-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/ref_removing-the-observability-operator.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+// This module can be included from assemblies using the following include statement:
+// include::<path>/proc_removing-the-cert-manager-operator.adoc[leveloffset=+1]
+
+// The file name and the ID are based on the module title. For example:
+// * file name: proc_doing-procedure-a.adoc
+// * ID: [id='proc_doing-procedure-a_{context}']
+// * Title: = Doing procedure A
+//
+// The ID is used as an anchor for linking to the module. Avoid changing
+// it after the module has been published to ensure existing links are not
+// broken.
+//
+// The `context` attribute enables module reuse. Every module's ID includes
+// {context}, which ensures that the module has a unique ID even if it is
+// reused multiple times in a guide.
+//
+// Start the title with a verb, such as Creating or Create. See also
+// _Wording of headings_ in _The IBM Style Guide_.
+
+[id="removing-the-observability-operator_{context}"]
+= Removing the {ObservabilityOperator}
+
+[role="_abstract"]
+If you are not using the {ObservabilityOperator} for any other applications, delete the Subscription, ClusterServiceVersion, and CustomResourceDefinitions.
+
+.Additional resources
+
+* link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/monitoring/cluster_observability_operator/installing-the-cluster-observability-operator.html#uninstalling-the-cluster-observability-operator-using-the-web-console_installing_the_cluster_observability_operator[Uninstalling the Cluster Observability Operator using the web console].
+* link:https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/operators/admin/olm-deleting-operators-from-cluster.html[Deleting Operators from a cluster].


### PR DESCRIPTION
Add removal instructions for Cluster Observability Operator, pointing at
the existing product documentation.

Closes: STF-1643
