### PR TITLE
PrometheusRules must reference monitoring.rhobs

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-custom-alerts.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-custom-alerts.adoc
@@ -32,7 +32,7 @@ You can add custom alerts to the `PrometheusRule` object that you created in xre
 +
 [source,bash]
 ----
-$ oc edit prometheusrules prometheus-alarm-rules
+$ oc edit prometheusrules.monitoring.rhobs prometheus-alarm-rules
 ----
 
 . Edit the `PrometheusRules` manifest.

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-snmp-traps.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-snmp-traps.adoc
@@ -70,7 +70,7 @@ $ oc project service-telemetry
 [source,yaml]
 ----
 $ oc apply -f - <<EOF
-apiVersion: monitoring.coreos.com/v1
+apiVersion: monitoring.rhobs/v1
 kind: PrometheusRule
 metadata:
   creationTimestamp: null

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-an-alert-rule-in-prometheus.adoc
@@ -19,7 +19,7 @@ $ oc project service-telemetry
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----
 $ oc apply -f - <<EOF
-apiVersion: monitoring.coreos.com/v1
+apiVersion: monitoring.rhobs/v1
 kind: PrometheusRule
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
The PrometheusRules and editing must all reference the new
monitoring.rhobs CRD vs the old monitoring.coreos.com CRD which was
provided by the community Prometheus Operator (and potentially
conflicted with user-workload monitoring, and openshift-monitoring). All
references to PrometheusRules now refer to the monitoring.rhobs CRD and
any CLI commands are expanded for the full CRD path.
