### PR TITLE
Add enable dashboard procedure

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_advanced-features.adoc
@@ -18,15 +18,10 @@ ifdef::include_when_16[]
 * xref:container-health-and-api-status_assembly-advanced-features[Monitoring container health and API status]
 endif::include_when_16[]
 
-
 //Dashboards
 include::../modules/con_dashboards.adoc[leveloffset=+1]
 include::../modules/proc_setting-up-grafana-to-host-the-dashboard.adoc[leveloffset=+2]
-ifdef::include_when_16[]
-// TODO: either rewrite or drop this procedure. We now provide the preferred downstream RHEL Grafana workload image in the deployment procedure.
-//include::../modules/proc_overriding-the-default-grafana-container-image.adoc[leveloffset=+2]
 include::../modules/proc_importing-dashboards.adoc[leveloffset=+2]
-endif::include_when_16[]
 include::../modules/proc_connecting-an-external-dashboard-system.adoc[leveloffset=+2]
 
 //Editing the metrics retention time period
@@ -68,12 +63,9 @@ include::../modules/con_resource-usage-of-openstack.adoc[leveloffset=+1]
 include::../modules/proc_disabling-resource-usage-monitoring-of-openstack-services.adoc[leveloffset=+2]
 
 //Monitoring container health
-
 include::../modules/con_container-health-and-api-status.adoc[leveloffset=+1]
 include::../modules/proc_disabling-container-health-and-api-status-monitoring.adoc[leveloffset=+2]
 endif::include_when_16[]
-
-
 
 //reset the context
 ifdef::parent-context[:context: {parent-context}]

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-observability-strategy.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-observability-strategy.adoc
@@ -24,7 +24,7 @@ EOF
 +
 [source,bash]
 ----
-$ for o in alertmanager/default prometheus/default elasticsearch/elasticsearch grafana/default; do oc delete $o; done
+$ for o in alertmanagers.monitoring.rhobs/default prometheuses.monitoring.rhobs/default elasticsearch/elasticsearch grafana/default-grafana; do oc delete $o; done
 ----
 +
 . To verify that all workloads are operating correctly, view the pods and the status of each pod:

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-the-overcloud.adoc
@@ -17,7 +17,7 @@ $ source ~/stackrc
 
 . Add your data collection and {MessageBus} environment files to the stack with your other environment files and deploy the overcloud:
 +
-[source,bash]
+[source,bash,options="nowrap"]
 ----
 (undercloud)$ openstack overcloud deploy --templates \
  -e [your environment files] \

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -5,7 +5,7 @@
 [role="_abstract"]
 The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. Service Telemetry Operator can enable a set of default dashboards that create the `GrafanaDashboard` objects that load dashboards into the Grafana instance.
 
-The following dashboards are loaded into Grafana when `graphing.grafana.dashboards.enabled` is set to `true`:
+Set the value of `graphing.grafana.dashboards.enabled` to `true` to load the following dashboards into Grafana :
 
 * Infrastructure dashboard
 * Cloud view dashboard

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -1,78 +1,67 @@
 
 [id="importing-dashboards_{context}"]
-= Importing dashboards
+= Enabling dashboards
 
 [role="_abstract"]
-The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. You can view example dashboards at https://github.com/infrawatch/dashboards.
+The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. A set of default dashboards can be enabled by Service Telemetry Operator which creates the `GrafanaDashboard` objects to result in dashboards loaded into the Grafana instance.
+
+The following dashboards are loaded into Grafana when `graphing.grafana.dashboards.enabled` is set to `true`:
+
+* Infrastructure dashboard
+* Cloud view dashboard
+* Virtual machine view dashboard
+* Memcached view dashboard
+
+Additional dashboards can be created and loaded into Grafana by using the GrafanaDashboard object. For more information about managing dashboards with Grafana Operator, see link:https://grafana.github.io/grafana-operator/docs/dashboards/[Dashboards] in the _Grafana Operator project documentation_.
+
+.Prerequisites
+
+* You've enabled graphing in the `ServiceTelemetry` object. For more information, see xref:setting-up-grafana-to-host-the-dashboard_assembly-advanced-features[].
 
 .Procedure
 
-. Import the infrastructure dashboard:
-+
-[source,bash,options="nowrap"]
-----
-$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/stf-1/rhos-dashboard.yaml
-
-grafanadashboard.integreatly.org/rhos-dashboard-1 created
-----
-. Import the cloud dashboard:
-+
-[WARNING]
-In the `enable-stf.yaml` file, ensure you set the value of the collectd `virt` plugin parameter `hostname_format` to `name uuid hostname`, otherwise some of the panels on the cloud dashboard display no information.
-ifdef::include_before_17[]
-For more information about the `virt` plugin, see link:{defaultURL}/operational_measurements/collectd-plugins_assembly[collectd plugins].
-endif::include_before_17[]
-ifdef::include_when_17[]
-For more information about the `virt` plugin, see link:{defaultURL}/managing_overcloud_observability/collectd-plugins_assembly[collectd plugins].
-endif::include_when_17[]
-+
-[source,bash,options="nowrap"]
-----
-$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/stf-1/rhos-cloud-dashboard.yaml
-
-grafanadashboard.integreatly.org/rhos-cloud-dashboard-1 created
-----
-. Import the virtual machine dashboard:
-+
-[source,bash,options="nowrap"]
-----
-$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/stf-1/virtual-machine-view.yaml
-
-grafanadashboard.integreatly.org/virtual-machine-view-1 configured
-----
-. Import the memcached dashboard:
-+
-[source,bash,options="nowrap"]
-----
-$ oc apply -f https://raw.githubusercontent.com/infrawatch/dashboards/master/deploy/stf-1/memcached-dashboard.yaml
-
-grafanadashboard.integreatly.org/memcached-dashboard-1 created
-----
-
-. Verify that the dashboards are available:
+. To enable the managed dashboards, create or modify the `ServiceTelemetry` object. Set `graphing.grafana.dashboards.enabled` to `true`:
 +
 [source,bash]
 ----
-$ oc get grafanadashboards
+$ oc edit stf default
 
-NAME                         AGE
-memcached-dashboard-1        7s
-rhos-cloud-dashboard-1       23s
-rhos-dashboard-1             29s
-virtual-machine-view-1       13s
+apiVersion: infra.watch/v1beta1
+kind: ServiceTelemetry
+...
+spec:
+  ...
+  graphing:
+    enabled: true
+    grafana:
+      dashboards:
+        enabled: true
+----
+
+. Verify the Grafana dashboards have been created. It will take some time before the dashboards have been created by Service Telemetry Operator:
++
+[source,bash,options="nowrap"]
+----
+$ oc get grafanadashboards.grafana.integreatly.org
+
+NAME                          NO MATCHING INSTANCES   LAST RESYNC   AGE
+memcached-dashboard-1                                 38s           38s
+rhos-cloud-dashboard-1                                39s           39s
+rhos-dashboard-1                                      39s           39s
+virtual-machine-dashboard-1                           37s           37s
 ----
 
 . Retrieve the Grafana route address:
 +
 [source,bash,options="nowrap"]
 ----
-$ oc get route grafana-route -ojsonpath='{.spec.host}'
+$ oc get route default-grafana-route -ojsonpath='{.spec.host}'
 
-grafana-route-service-telemetry.apps.infra.watch
+default-grafana-route-service-telemetry.apps.infra.watch
 ----
 
 . In a web browser, navigate to https://_<grafana_route_address>_. Replace _<grafana_route_address>_ with the value that you retrieved in the previous step.
 
 . Log in with OpenShift credentials. For more information about logging in, see xref:accessing-uis-for-stf-components_assembly-installing-the-core-components-of-stf[].
 
-. To view the dashboard, click *Dashboards* and *Manage*.
+. To view the dashboard, click *Dashboards* and *Browse*. The managed dashboards will be available in the _service-telemetry_ folder.

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -38,7 +38,7 @@ spec:
         enabled: true
 ----
 
-. Verify the Grafana dashboards have been created. It will take some time before the dashboards have been created by Service Telemetry Operator:
+. Verify that the Grafana dashboards are created. The process of Service Telemetry Operator creating the dashboards might take some time.
 +
 [source,bash,options="nowrap"]
 ----

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -12,7 +12,7 @@ Set the value of `graphing.grafana.dashboards.enabled` to `true` to load the fol
 * Virtual machine view dashboard
 * Memcached view dashboard
 
-Additional dashboards can be created and loaded into Grafana by using the GrafanaDashboard object. For more information about managing dashboards with Grafana Operator, see link:https://grafana.github.io/grafana-operator/docs/dashboards/[Dashboards] in the _Grafana Operator project documentation_.
+You can use the `GrafanaDashboard` object to create and load additional dashboards into Grafana. For more information about managing dashboards with Grafana Operator, see link:https://grafana.github.io/grafana-operator/docs/dashboards/[Dashboards] in the _Grafana Operator project documentation_.
 
 .Prerequisites
 

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -3,7 +3,7 @@
 = Enabling dashboards
 
 [role="_abstract"]
-The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. A set of default dashboards can be enabled by Service Telemetry Operator which creates the `GrafanaDashboard` objects to result in dashboards loaded into the Grafana instance.
+The Grafana Operator can import and manage dashboards by creating `GrafanaDashboard` objects. Service Telemetry Operator can enable a set of default dashboards that create the `GrafanaDashboard` objects that load dashboards into the Grafana instance.
 
 The following dashboards are loaded into Grafana when `graphing.grafana.dashboards.enabled` is set to `true`:
 

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -16,7 +16,7 @@ You can use the `GrafanaDashboard` object to create and load additional dashboar
 
 .Prerequisites
 
-* You've enabled graphing in the `ServiceTelemetry` object. For more information, see xref:setting-up-grafana-to-host-the-dashboard_assembly-advanced-features[].
+* You enabled graphing in the `ServiceTelemetry` object. For more information about graphing, see xref:setting-up-grafana-to-host-the-dashboard_assembly-advanced-features[].
 
 .Procedure
 

--- a/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_importing-dashboards.adoc
@@ -64,4 +64,4 @@ default-grafana-route-service-telemetry.apps.infra.watch
 
 . Log in with OpenShift credentials. For more information about logging in, see xref:accessing-uis-for-stf-components_assembly-installing-the-core-components-of-stf[].
 
-. To view the dashboard, click *Dashboards* and *Browse*. The managed dashboards will be available in the _service-telemetry_ folder.
+. To view the dashboard, click *Dashboards* and *Browse*. The managed dashboards are available in the _service-telemetry_ folder.


### PR DESCRIPTION
Update the import dashboards procedure to be enable dashboards procedure
now that STF has the ability to manage the dashboards which were
formerly imported via URL.

Also includes some minor procedure updates in related areas that were
referenced in dashboard documentation.

Resolves: JIRA#STF-1624
