### PR TITLE
Update OCP version support status

### DIFF
--- a/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_installing-the-core-components-of-stf.adoc
@@ -21,7 +21,7 @@ ifeval::["{SupportedOpenShiftVersion}" == "{NextSupportedOpenShiftVersion}"]
 * {OpenShift} version {SupportedOpenShiftVersion} is running.
 endif::[]
 ifeval::["{SupportedOpenShiftVersion}" != "{NextSupportedOpenShiftVersion}"]
-* An {OpenShift} version inclusive of {SupportedOpenShiftVersion} through {NextSupportedOpenShiftVersion} is running.
+* An {OpenShift} Extended Update Support (EUS) release version {SupportedOpenShiftVersion} or {NextSupportedOpenShiftVersion} is running.
 endif::[]
 * You have prepared your {OpenShift} environment and ensured that there is persistent storage and enough resources to run the {ProjectShort} components on top of the {OpenShift} environment. For more information about {ProjectShort} performance, see the Red Hat Knowledge Base article https://access.redhat.com/articles/4907241[Service Telemetry Framework Performance and Scaling].
 * Your environment is fully connected. {ProjectShort} does not work in a {OpenShift}-disconnected environments or network proxy environments.
@@ -32,7 +32,7 @@ ifeval::["{SupportedOpenShiftVersion}" == "{NextSupportedOpenShiftVersion}"]
 {ProjectShort} is compatible with {OpenShift} version {SupportedOpenShiftVersion}
 endif::[]
 ifeval::["{SupportedOpenShiftVersion}" != "{NextSupportedOpenShiftVersion}"]
-{ProjectShort} is compatible with {OpenShift} version {SupportedOpenShiftVersion} through {NextSupportedOpenShiftVersion}.
+{ProjectShort} is compatible with {OpenShift} versions {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
 endif::[]
 endif::[]
 
@@ -42,6 +42,7 @@ endif::[]
 * For more information about Operator catalogs, see https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/operators/understanding/olm-rh-catalogs.html[_Red Hat-provided Operator catalogs_].
 * For more information about the cert-manager Operator for Red Hat, see https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/security/cert_manager_operator/index.html[_cert-manager Operator for Red Hat OpenShift overview_].
 * For more information about {ObservabilityOperator}, see https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/monitoring/cluster_observability_operator/cluster-observability-operator-overview.html[_Cluster Observability Operator Overview_].
+* For more information about OpenShift life cycle policy and Extended Update Support (EUS), see https://access.redhat.com/support/policy/updates/openshift[_Red Hat OpenShift Container Platform Life Cycle Policy_].
 
 include::../modules/con_deploying-stf-to-the-openshift-environment.adoc[leveloffset=+1]
 

--- a/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
+++ b/doc-Service-Telemetry-Framework/assemblies/assembly_introduction-to-stf.adoc
@@ -31,7 +31,7 @@ ifeval::["{SupportedOpenShiftVersion}" == "{NextSupportedOpenShiftVersion}"]
 {ProjectShort} is compatible with {OpenShift} version {SupportedOpenShiftVersion}
 endif::[]
 ifeval::["{SupportedOpenShiftVersion}" != "{NextSupportedOpenShiftVersion}"]
-{ProjectShort} is compatible with {OpenShift} version {SupportedOpenShiftVersion} through {NextSupportedOpenShiftVersion}.
+{ProjectShort} is compatible with {OpenShift} Extended Update Support (EUS) release versions {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}.
 endif::[]
 endif::[]
 
@@ -40,6 +40,7 @@ endif::[]
 * https://access.redhat.com/documentation/en-us/openshift_container_platform/{NextSupportedOpenShiftVersion}/[{OpenShift} product documentation]
 * https://access.redhat.com/articles/4907241[Service Telemetry Framework Performance and Scaling]
 * https://docs.openshift.com/container-platform/{NextSupportedOpenShiftVersion}/welcome/index.html#cluster-installer-activities[OpenShift Container Platform {NextSupportedOpenShiftVersion} Documentation]
+* https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy]
 
 
 

--- a/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_stf-architecture.adoc
@@ -87,9 +87,11 @@ ifeval::["{SupportedOpenShiftVersion}" == "{NextSupportedOpenShiftVersion}"]
 * {OpenShift} {SupportedOpenShiftVersion}
 endif::[]
 ifeval::["{SupportedOpenShiftVersion}" != "{NextSupportedOpenShiftVersion}"]
-* {OpenShift} {SupportedOpenShiftVersion} through {NextSupportedOpenShiftVersion}
+* {OpenShift} Extended Update Support (EUS) releases {SupportedOpenShiftVersion} and {NextSupportedOpenShiftVersion}
 endif::[]
 * Infrastructure platform
+
+For more information about the {OpenShift} EUS releases, see link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
 
 [[osp-stf-server-side-monitoring]]
 .Server-side STF monitoring infrastructure


### PR DESCRIPTION
Update the version support status to specifically say that STF is
supported on OCP EUS releases. While the STF bundles are generated for a
range of releases, this is to support the ability of customers to
upgrade OCP clusters between EUS releases without needing to remove STF
first. Only minor testing is done against standard lifecycle releases of
OCP (odd-numbered minor releases).
