### PR TITLE
mg-master_RHOSPDOC-1200_update-section2.4-network-considerations

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/con_network-considerations-for-service-telemetry-framework.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_network-considerations-for-service-telemetry-framework.adoc
@@ -3,4 +3,4 @@
 [id="con-network-considerations-for-service-telemetry-framework_{context}"]
 = Network considerations for Service Telemetry Framework
 
-You can only deploy {Project} ({ProjectShort}) in a fully connected network environment. You cannot deploy {ProjectShort} in {OpenShift}-disconnected environments or network proxy environments.
+You can deploy {Project} ({ProjectShort}) in fully-connected network environments or in {OpenShift}-disconnected environments. You cannot deploy {ProjectShort} in network proxy environments.


### PR DESCRIPTION
BEFORE:
Network considerations for Service Telemetry Framework
You can only deploy Service Telemetry Framework (STF) in a fully connected network environment. You cannot deploy STF in OpenShift-disconnected environments or network proxy environments.
AFTER:
Network considerations for Service Telemetry Framework
You can deploy Service Telemetry Framework (STF) in a fully-connected network environment or an OpenShift-disconnected environment. You cannot deploy STF in network proxy environments.
