### PR TITLE
Drop OpenShiftShort attribute

### DIFF
--- a/common/global/stf-attributes.adoc
+++ b/common/global/stf-attributes.adoc
@@ -39,7 +39,6 @@ endif::[]
 ifeval::["{build}" == "upstream"]
 :ObservabilityOperator: Observability{nbsp}Operator
 :OpenShift: OpenShift
-:OpenShiftShort: OKD
 :OpenStack: OpenStack
 :OpenStackShort: OSP
 :OpenStackVersion: Wallaby
@@ -58,7 +57,6 @@ endif::[]
 ifeval::["{build}" == "downstream"]
 :ObservabilityOperator: Cluster{nbsp}Observability{nbsp}Operator
 :OpenShift: Red{nbsp}Hat{nbsp}OpenShift{nbsp}Container{nbsp}Platform
-:OpenShiftShort: OCP
 :OpenStack: Red{nbsp}Hat{nbsp}OpenStack{nbsp}Platform
 :OpenStackShort: RHOSP
 :OpenStackVersion: 17.1

--- a/doc-Service-Telemetry-Framework/modules/con_manifest-overrides.adoc
+++ b/doc-Service-Telemetry-Framework/modules/con_manifest-overrides.adoc
@@ -26,7 +26,7 @@
 = Customizing the deployment
 
 [role="_abstract"]
-The Service Telemetry Operator watches for a `ServiceTelemetry` manifest to load into {OpenShift} ({OpenShiftShort}). The Operator then creates other objects in memory, which results in the dependent Operators creating the workloads they are responsible for managing.
+The Service Telemetry Operator watches for a `ServiceTelemetry` manifest to load into {OpenShift}. The Operator then creates other objects in memory, which results in the dependent Operators creating the workloads they are responsible for managing.
 
 [WARNING]
 ====

--- a/doc-Service-Telemetry-Framework/modules/proc_overriding-a-managed-manifest.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_overriding-a-managed-manifest.adoc
@@ -32,7 +32,7 @@ $ oc project service-telemetry
 $ oc edit servicetelemetry default
 ----
 
-. To modify the `ServiceTelemetry` object, provide a manifest override parameter and the contents of the manifest to write to {OpenShiftShort} instead of the defaults provided by {ProjectShort}.
+. To modify the `ServiceTelemetry` object, provide a manifest override parameter and the contents of the manifest to write to {OpenShift} instead of the defaults provided by {ProjectShort}.
 +
 [NOTE]
 ====


### PR DESCRIPTION
The documentation style indicates we shouldn't be using OCP or OKD short
forms of OpenShift, so I'm dropping that.