### PR TITLE
Corrected the saslPassword field by removing 'pass:' prefix in config

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-director-operator-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-director-operator-for-the-overcloud.adoc
@@ -41,7 +41,7 @@ data:
               verifyHostname: false
               sslProfile: sslProfile
               saslUsername: guest@default-interconnect
-              saslPassword: pass:<password_from_stf>
+              saslPassword: <password_from_stf>
 
         MetricsQdrSSLProfiles:
             - name: sslProfile

--- a/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_configuring-the-stf-connection-for-the-overcloud.adoc
@@ -43,7 +43,7 @@ parameter_defaults:
           verifyHostname: false
           sslProfile: sslProfile
           saslUsername: guest@default-interconnect
-          saslPassword: pass:<password_from_stf>
+          saslPassword: <password_from_stf>
 
     MetricsQdrSSLProfiles:
         - name: sslProfile


### PR DESCRIPTION
### Summary

This pull request fixes the `saslPassword` field configuration in the following files:

- `proc_configuring-the-stf-connection-for-the-overcloud.adoc`
- `proc_configuring-the-stf-connection-for-director-operator-for-the-overcloud.adoc`

### Description

Changed `saslPassword: pass:<password_from_stf>` to `saslPassword: <password_from_stf>` to correct the field and enable proper connection.

### Verification

Changes have been tested and confirmed to work correctly.


