### PR TITLE
Report root filesystem metrics

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
@@ -90,6 +90,9 @@ data:
              local:
                host: "%{hiera('fqdn_canonical')}"
                port: 11211
+
+          # report root filesystem storage metrics
+          collectd::plugin::df::ignoreselected: false
 ----
 
 [role="_additional-resources"]

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -141,5 +141,8 @@ parameter_defaults:
           local:
             host: "%{hiera('fqdn_canonical')}"
             port: 11211
+
+        # report root filesystem storage metrics
+        collectd::plugin::df::ignoreselected: false
 ----
 endif::include_when_16[]


### PR DESCRIPTION
After this change, df plugin reports disk utilization for root partition which is better than reporting utilization for devtmpfs, overlay and shm partitions.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2291464