### PR TITLE
Enable virt plugin's stats necessary for stf dashboard

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-director-operator-for-stf.adoc
@@ -54,8 +54,10 @@ data:
         CollectdConnectionType: amqp1
         CollectdAmqpInterval: 30
         CollectdDefaultPollingInterval: 30
-        CollectdExtraPlugins:
-        - vmem
+
+        # to collect information about the virtual memory subsystem of the kernel
+        # CollectdExtraPlugins:
+        # - vmem
 
         # set standard prefixes for where metrics are published to QDR
         MetricsQdrAddresses:
@@ -74,12 +76,15 @@ data:
            # note: this may need an adjustment if there are many metrics to be sent.
            collectd::plugin::amqp1::send_queue_limit: 5000
 
-           # receive extra information about virtual memory
-           collectd::plugin::vmem::verbose: true
+           # receive extra information about virtual memory, vmem plugin must be enabled
+           # collectd::plugin::vmem::verbose: true
 
            # provide name and uuid in addition to hostname for better correlation
            # to ceilometer data
            collectd::plugin::virt::hostname_format: "name uuid hostname"
+
+           # to capture all extra_stats metrics, comment out below config
+           collectd::plugin::virt::extra_stats: cpu_util vcpu disk
 
            # provide the human-friendly name of the virtual instance
            collectd::plugin:ConfigMap :virt::plugin_instance_format: metadata

--- a/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_creating-the-base-configuration-for-stf.adoc
@@ -35,8 +35,10 @@ parameter_defaults:
     CollectdConnectionType: amqp1
     CollectdAmqpInterval: 30
     CollectdDefaultPollingInterval: 30
-    CollectdExtraPlugins:
-    - vmem
+
+    # to collect information about the virtual memory subsystem of the kernel
+    # CollectdExtraPlugins:
+    # - vmem
 
     # set standard prefixes for where metrics are published to QDR
     MetricsQdrAddresses:
@@ -55,8 +57,8 @@ parameter_defaults:
         # note: Adjust the value of the `send_queue_limit` to handle your required volume of metrics.
         collectd::plugin::amqp1::send_queue_limit: 5000
 
-        # receive extra information about virtual memory
-        collectd::plugin::vmem::verbose: true
+        # receive extra information about virtual memory, vmem plugin must be enabled
+        # collectd::plugin::vmem::verbose: true
 
         # set memcached collectd plugin to report its metrics by hostname
         # rather than host IP, ensuring metrics in the dashboard remain uniform
@@ -131,6 +133,9 @@ parameter_defaults:
         # provide name and uuid in addition to hostname for better correlation
         # to ceilometer data
         collectd::plugin::virt::hostname_format: "name uuid hostname"
+
+        # to capture all extra_stats metrics, comment out below config
+        collectd::plugin::virt::extra_stats: cpu_util vcpu disk
 
         # provide the human-friendly name of the virtual instance
         collectd::plugin::virt::plugin_instance_format: metadata


### PR DESCRIPTION
This change overrides the default stats of virt plugin by enabling just the ones that are needed for stf dashboard. This avoids capturing the metrics that are not visualized in the dashboard.

Also, disable `vmem` plugin by default. There are no panels in stf dashboard that visualize virtual memory subsystem of the kernel.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2283987