### PR TITLE
Update COO channel to stable

### DIFF
--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-observability-operator.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-observability-operator.adoc
@@ -22,7 +22,7 @@ metadata:
   name: cluster-observability-operator
   namespace: openshift-operators
 spec:
-  channel: development
+  channel: stable
   installPlanApproval: Automatic
   name: cluster-observability-operator
   source: redhat-operators

--- a/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-on-openshift-disconnected-environments.adoc
+++ b/doc-Service-Telemetry-Framework/modules/proc_deploying-stf-on-openshift-disconnected-environments.adoc
@@ -47,7 +47,7 @@ mirror:
           - name: stable-1.5
       - name: cluster-observability-operator
         channels:
-          - name: development
+          - name: stable
 ----
 
 


### PR DESCRIPTION
COO 1.0.0 now publishes their artifacts in the stable channel

The development channel that was in use is no longer available

Update docs to reflect this